### PR TITLE
Lock file feature

### DIFF
--- a/MongoBackup/Backup.py
+++ b/MongoBackup/Backup.py
@@ -145,7 +145,9 @@ class Backup(object):
 
             logging.info("Cleanup complete. Exiting")
 
-            self._lock.release()
+            if self._lock:
+                self._lock.release()
+
             sys.exit(1)
 
     def exception(self, error_message):

--- a/MongoBackup/Backup.py
+++ b/MongoBackup/Backup.py
@@ -143,10 +143,10 @@ class Backup(object):
                     self.backup_name
                 ))
 
-            logging.info("Cleanup complete. Exiting")
-
             if self._lock:
                 self._lock.release()
+
+            logging.info("Cleanup complete. Exiting")
 
             sys.exit(1)
 

--- a/MongoBackup/Common/Lock.py
+++ b/MongoBackup/Common/Lock.py
@@ -24,6 +24,7 @@ class Lock:
             raise Exception, "Could not acquire lock!", None
     
     def release(self):
-        logging.debug("Releasing exclusive lock on file: %s" % self.lock_file)
-        self._lock.close()
-        return os.remove(self.lock_file)
+        if self._lock:
+            logging.debug("Releasing exclusive lock on file: %s" % self.lock_file)
+            self._lock.close()
+            return os.remove(self.lock_file)

--- a/MongoBackup/Common/Lock.py
+++ b/MongoBackup/Common/Lock.py
@@ -27,4 +27,5 @@ class Lock:
         if self._lock:
             logging.debug("Releasing exclusive lock on file: %s" % self.lock_file)
             self._lock.close()
+            self._lock = None
             return os.remove(self.lock_file)

--- a/MongoBackup/Common/Lock.py
+++ b/MongoBackup/Common/Lock.py
@@ -3,6 +3,7 @@ import logging
 
 from fcntl import flock, LOCK_EX, LOCK_NB
 
+
 class Lock:
     def __init__(self, lock_file):
         self.lock_file = lock_file

--- a/MongoBackup/Common/Lock.py
+++ b/MongoBackup/Common/Lock.py
@@ -1,0 +1,28 @@
+import os
+import logging
+
+from fcntl import flock, LOCK_EX, LOCK_NB
+
+class Lock:
+    def __init__(self, lock_file):
+        self.lock_file = lock_file
+    
+        self._lock = None
+        self.acquire()
+    
+    def acquire(self):
+        try:
+            self._lock = open(self.lock_file, "w")
+            flock(self._lock, LOCK_EX | LOCK_NB)
+            logging.debug("Acquired exclusive lock on file: %s" % self.lock_file)
+            return self._lock
+        except Exception, e:
+            logging.debug("Error acquiring lock on file: %s" % self.lock_file)
+            if self._lock:
+                self._lock.close()
+            raise Exception, "Could not acquire lock!", None
+    
+    def release(self):
+        logging.debug("Releasing exclusive lock on file: %s" % self.lock_file)
+        self._lock.close()
+        return os.remove(self.lock_file)

--- a/MongoBackup/Common/__init__.py
+++ b/MongoBackup/Common/__init__.py
@@ -1,1 +1,2 @@
 from LocalCommand import LocalCommand
+from Lock import Lock

--- a/MongoBackup/__init__.py
+++ b/MongoBackup/__init__.py
@@ -81,6 +81,7 @@ def run():
     parser.add_option("--no-archive", dest="no_archiver", help="Disable archiving of backups directories post-resolving", action="store_true", default=False)
     parser.add_option("--no-archive-gzip", dest="no_archiver_gzip", help="Disable gzip compression of archive files", action="store_true", default=False)
     parser.add_option("--lazy", dest="no_oplog_tailer", help="Disable tailing/resolving of clusterwide oplogs. This makes a shard-consistent, not cluster-consistent backup", action="store_true", default=False)
+    parser.add_option("--lock-file", dest="lock_file", help="Location of lock file (default: /tmp/%s.lock)" % os.path.basename(sys.argv[0]), default="/tmp/%s.lock" % os.path.basename(sys.argv[0]))
     parser.set_defaults()
 
     options = handle_options(parser)


### PR DESCRIPTION
Added exclusive lock capabilities after seeing it is possible for many processes to overlap each other. Lock is acquired at beginning of backup run and is released on success and failure (inside the exception handler). Lock file path is overridable.

Example logging + backup running:

```
$ mongodb-consistent-backup -v -c /etc/rdba/percona-backup-mongo.yml 
[2016-06-17 16:32:41,863] [DEBUG] [MainProcess] [DB:connect:20] Getting MongoDB connection to centos7-mongos1:27017
[2016-06-17 16:32:41,874] [DEBUG] [MainProcess] [Lock:acquire:17] Acquired exclusive lock on file: /tmp/mongodb-consistent-backup.lock
[2016-06-17 16:32:41,874] [INFO] [MainProcess] [Backup:run:184] Starting backup of centos7-mongos1:27017 in sharded mode
…
…
[2016-06-17 16:34:33,840] [INFO] [MainProcess] [Archiver:run:102] Archiver threads completed
[2016-06-17 16:34:33,840] [DEBUG] [MainProcess] [Lock:release:26] Releasing exclusive lock on file: /tmp/mongodb-consistent-backup.lock
[2016-06-17 16:34:33,840] [INFO] [MainProcess] [Backup:run:303] Backup completed in 111.988605022 sec
```

Output if you try to run another backup at the same time:

```
[tim@centos7 ~]$ mongodb-consistent-backup -v -c /etc/rdba/percona-backup-mongo.yml
[2016-06-17 16:32:45,088] [DEBUG] [MainProcess] [DB:connect:20] Getting MongoDB connection to centos7-mongos1:27017
[2016-06-17 16:32:45,095] [DEBUG] [MainProcess] [Lock:acquire:20] Error acquiring lock on file: /tmp/mongodb-consistent-backup.lock
[2016-06-17 16:32:45,095] [CRITICAL] [MainProcess] [Backup:run:159] Could not acquire lock! Is another mongodb-consistent-backup process running? Exiting
```