### PR TITLE
Subprocess.Popen stall fix for Issue #8

### DIFF
--- a/MongoBackup/Common/LocalCommand.py
+++ b/MongoBackup/Common/LocalCommand.py
@@ -37,7 +37,7 @@ class LocalCommand:
             self._process = Popen(self.command_line, stdout=PIPE, stderr=PIPE)
             while self._process.poll() is None:
                 self.parse_output()
-                sleep(0.25)
+                sleep(0.1)
         except Exception, e:
             raise e
     

--- a/MongoBackup/Common/LocalCommand.py
+++ b/MongoBackup/Common/LocalCommand.py
@@ -11,8 +11,6 @@ class LocalCommand:
         self.verbose       = verbose
 
         self.output   = []
-        self.stdout   = None
-        self.stderr   = None
         self._process = None
 
         self.command_line = [self.command]
@@ -22,10 +20,10 @@ class LocalCommand:
     def parse_output(self):
         if self._process:
             try:
-                self.stdout, self.stderr = self._process.communicate()
-                output = self.stdout.strip()
-                if output == "" and self.stderr.strip() != "":
-                    output = self.stderr.strip()
+                stdout, stderr = self._process.communicate()
+                output = stdout.strip()
+                if output == "" and stderr.strip() != "":
+                    output = stderr.strip()
                 if not output == "":
                     self.output.append("\n\t".join(output.split("\n")))
             except Exception, e:
@@ -45,7 +43,7 @@ class LocalCommand:
             raise Exception, "%s command failed with exit code %i! Stderr output:\n%s" % (
                 self.command,
                 self._process.returncode,
-                self.stderr.strip()
+                "\n".join(self.output)
             ), None
         elif self.verbose:
             if len(self.output) > 0:


### PR DESCRIPTION
Fix to resolve #8.

- Parse output from Popen PIPE every poll to make sure the pipe buffer never fills, which stalls the shell command. Before we only checked after the command execution, which can easily fill the PIPE buffer to 100%. From the subprocess docs: 

> "Warning This will deadlock when using stdout=PIPE and/or stderr=PIPE and the child process generates enough output to a pipe such that it blocks waiting for the OS pipe buffer to accept more data.

- Moved Popen thread polling from 500ms down to 100ms so we empty the buffers often. The stall takes minutes/hours on a large deployment so this should be plenty.
- Moved output to an array to facilitate the change to calling the output parser N times. Changed logging to accept an array for output and display it the same as before.

Logging output is unchanged for this PR to keep changes small, look out for a future PR for realtime thread logging.

Functional tests are passing with this change.