### PR TITLE
Fixing error for 1 vs 3 args that signal() causes in Tail.py

### DIFF
--- a/MongoBackup/Oplog/Tail.py
+++ b/MongoBackup/Oplog/Tail.py
@@ -58,7 +58,7 @@ class OplogTail(Process):
     def stop(self):
         self._stop.set()
 
-    def close(self):
+    def close(self, code=None, frame=None):
         return self.stop()
 
     def stopped(self):


### PR DESCRIPTION
This error happens because signal() sends 2 args (code+frame) that we don't need, but nonetheless must accept:

```
[2016-06-19 19:53:52,630] [INFO] [MainProcess] [Tailer:stop:55] Stopping oplog tailing threads
    self.run()
    self.run()
  File "/home/tim/.pex/install/MongoBackup-0.0.1b0-py2-none-any.whl.25dcf8347ce7b7f50bc65cdaa55f3e0061548167/MongoBackup-0.0.1b0-py2-none-any.whl/MongoBackup/Oplog/Tail.py", line 102, in run
  File "/home/tim/.pex/install/MongoBackup-0.0.1b0-py2-none-any.whl.25dcf8347ce7b7f50bc65cdaa55f3e0061548167/MongoBackup-0.0.1b0-py2-none-any.whl/MongoBackup/Oplog/Tail.py", line 102, in run
    sleep(1)
    sleep(1)
TypeError: close() takes exactly 1 argument (3 given)
TypeError: close() takes exactly 1 argument (3 given)
    self.run()
  File "/home/tim/.pex/install/MongoBackup-0.0.1b0-py2-none-any.whl.25dcf8347ce7b7f50bc65cdaa55f3e0061548167/MongoBackup-0.0.1b0-py2-none-any.whl/MongoBackup/Oplog/Tail.py", line 102, in run
    sleep(1)
```

This PR fixes that.