### PR TITLE
Moving thread-complete check to response queue

### DIFF
--- a/MongoBackup/Mongodump.py
+++ b/MongoBackup/Mongodump.py
@@ -41,14 +41,6 @@ class Mongodump(Process):
         if self._command:
             logging.debug("Killing running subprocess/command: %s" % self._command.command)
             self._command.close()
-            self.response_queue.put({
-                'host': self.host,
-                'port': self.port,
-                'file': self.oplog_file,
-                'count': oplog.count(),
-                'last_ts': oplog.last_ts(),
-                'first_ts': oplog.first_ts()
-            })
 
     def run(self):
         logging.info("Starting mongodump (with oplog) backup of %s/%s:%i" % (

--- a/MongoBackup/Mongodumper.py
+++ b/MongoBackup/Mongodumper.py
@@ -132,11 +132,11 @@ class Mongodumper:
             if backup['completed']:
                 completed += 1
 
-        # fail if all threads did not complete
-        if not completed == len(self.threads):
+        # check if all threads completed
+        if completed == len(self.threads):
+            logging.info("All mongodump backups completed")
+        else:
             raise Exception, "Not all mongodump threads completed successfully!", None
-
-        logging.info("All mongodump backups completed")
 
         return self._summary
 

--- a/MongoBackup/Mongodumper.py
+++ b/MongoBackup/Mongodumper.py
@@ -113,16 +113,15 @@ class Mongodumper:
         for thread in self.threads:
             thread.start()
 
-        # wait for all threads to finish and check their status
+        # wait for all threads to finish
         for thread in self.threads:
             thread.join()
-            if not thread.complete():
-                raise Exception, "Not all mongodump threads completed successfully!", None
 
         # sleep for 3 sec to fix logging order
         sleep(3)
 
         # get oplog summaries from the queue
+        completed = 0
         while not self.response_queue.empty():
             backup = self.response_queue.get()
             host = backup['host']
@@ -130,6 +129,12 @@ class Mongodumper:
             if host not in self._summary:
                 self._summary[host] = {}
             self._summary[host][port] = backup
+            if backup['completed']:
+                completed += 1
+
+        # fail if all threads did not complete
+        if not completed == len(self.threads):
+            raise Exception, "Not all mongodump threads completed successfully!", None
 
         logging.info("All mongodump backups completed")
 


### PR DESCRIPTION
Use the response queue to check for success instead of a cross-thread method call (thread.complete()), which seems to work inconsistently with threading in at least one environment. The fix is we use the queue instead and if we don't see the correct number of responses with 'completed: True', in the queue we fail.

The response queue (multiprocessing.Queue) object has been working solidly and consistently in all environments we've deployed to so this is highly likely to resolve the problem and it is passing all my testing.