### PR TITLE
Log version + git-commit info on startup

### DIFF
--- a/MongoBackup/Backup.py
+++ b/MongoBackup/Backup.py
@@ -79,8 +79,10 @@ class Backup(object):
         # Check for required fields:
         required = ['program_name', 'version', 'git_commit', 'backup_name', 'backup_binary', 'backup_location'] 
         for field in required:
-            if not getattr(self, field):
-                raise Exception, 'Field: %s is required by this class!', None
+            try:
+                getattr(self, field)
+            except Exception:
+                raise Exception, 'Field: %s is required by %s!' % (field, __name__), None
 
         # Set default lock file:
 	if not self.lock_file:

--- a/MongoBackup/Backup.py
+++ b/MongoBackup/Backup.py
@@ -20,7 +20,9 @@ from Upload import UploadS3
 
 class Backup(object):
     def __init__(self, options):
-        self.program_name = 'mongodb-consistent-backup'
+        self.program_name = None
+        self.version = None
+        self.git_commit = None
         self.host = 'localhost'
         self.port = 27017
         self.authdb = 'admin'
@@ -30,7 +32,7 @@ class Backup(object):
         self.max_repl_lag_secs = 5
         self.backup_name = None
         self.backup_binary = None
-        self.backup_location = "/backups"
+        self.backup_location = None
         self.dump_gzip = False
         self.balancer_wait_secs = 300
         self.balancer_sleep = 10
@@ -73,6 +75,12 @@ class Backup(object):
         # Setup options are properies and connection to node
         for option in vars(options):
             setattr(self, option, getattr(options, option))
+
+        # Check for required fields:
+        required = ['program_name', 'version', 'git_commit', 'backup_name', 'backup_binary', 'backup_location'] 
+        for field in required:
+            if not getattr(self, field):
+                raise Exception, 'Field: %s is required by this class!', None
 
         # Set default lock file:
 	if not self.lock_file:
@@ -155,6 +163,8 @@ class Backup(object):
         return self.cleanup_and_exit(None, None)
 
     def run(self):
+        logging.info("Starting %s version %s (git commit hash: %s)" % (self.program_name, self.version, self.git_commit))
+
         try:
             self._lock = Lock(self.lock_file)
         except Exception, e:
@@ -162,7 +172,7 @@ class Backup(object):
             sys.exit(1)
 
         if not self.is_mongos:
-            logging.info("Starting backup of %s:%s in replset mode" % (self.host, self.port))
+            logging.info("Running backup of %s:%s in replset mode" % (self.host, self.port))
 
             try:
                 self.mongodumper = Mongodumper(
@@ -183,7 +193,7 @@ class Backup(object):
                 self.exception("Problem performing replset mongodump! Error: %s" % e)
 
         else:
-            logging.info("Starting backup of %s:%s in sharded mode" % (self.host, self.port))
+            logging.info("Running backup of %s:%s in sharded mode" % (self.host, self.port))
 
             # connect to balancer and stop it
             try:

--- a/MongoBackup/__init__.py
+++ b/MongoBackup/__init__.py
@@ -5,8 +5,9 @@ from optparse import OptionParser
 from yaml import load
 from Backup import Backup
 
-__version__    = '#.#.#'
-__git_commit__ = 'GIT_COMMIT_HASH'
+__version__ = '#.#.#'
+git_commit  = 'GIT_COMMIT_HASH'
+prog_name   = os.path.basename(sys.argv[0])
 
 
 def handle_options(parser):
@@ -51,7 +52,7 @@ def printPythonVersions():
 # noinspection PyUnusedLocal
 def run():
     parser = OptionParser()
-    parser.add_option("--version", dest="version", help="Display version number and exit", action="store_true", default=False)
+    parser.add_option("--version", dest="print_version", help="Display version number and exit", action="store_true", default=False)
     parser.add_option("-v", "--verbose", dest="verbose", help="Increase verbosity", action="store_true", default=False)
     parser.add_option("-c", "--config", dest="config", help="Use YAML config file as defaults")
     parser.add_option("-l", "--location", dest="backup_location", help="Directory to save the backup(s) to (required)")
@@ -81,15 +82,17 @@ def run():
     parser.add_option("--no-archive", dest="no_archiver", help="Disable archiving of backups directories post-resolving", action="store_true", default=False)
     parser.add_option("--no-archive-gzip", dest="no_archiver_gzip", help="Disable gzip compression of archive files", action="store_true", default=False)
     parser.add_option("--lazy", dest="no_oplog_tailer", help="Disable tailing/resolving of clusterwide oplogs. This makes a shard-consistent, not cluster-consistent backup", action="store_true", default=False)
-    parser.add_option("--lock-file", dest="lock_file", help="Location of lock file (default: /tmp/%s.lock)" % os.path.basename(sys.argv[0]), default="/tmp/%s.lock" % os.path.basename(sys.argv[0]))
+    parser.add_option("--lock-file", dest="lock_file", help="Location of lock file (default: /tmp/%s.lock)" % prog_name, default="/tmp/%s.lock" % prog_name)
     parser.set_defaults()
 
     options = handle_options(parser)
 
-    if options.version:
-        binary = os.path.basename(sys.argv[0])
-        print "%s version: %s, git commit hash: %s" % (binary, __version__, __git_commit__)
+    options.program_name = prog_name
+    options.version      = __version__
+    options.git_commit   = git_commit
 
+    if options.print_version:
+        print "%s version: %s, git commit hash: %s" % (prog_name, __version__, git_commit)
         if options.verbose:
             printPythonVersions()
         sys.exit(0)


### PR DESCRIPTION
1. Made program name a variable in __init__.py (used many times).
2. Passed all version/git/prog-name info down to Backup.py.
3. Added required field check to Backup.py.
4. Added logging of version on startup of tool, example:

```
$ mongodb-consistent-backup -c /etc/rdba/percona-backup-mongo.yml
[2016-06-26 17:05:30,906] [INFO] [MainProcess] [Backup:run:166] Starting mongodb-consistent-backup version 0.0.1beta (git commit hash: 79e9b7d1d8c86e909597522573663e887ecd1dd5)
[2016-06-26 17:05:30,906] [INFO] [MainProcess] [Backup:run:196] Running backup of centos7-mongos1:27017 in sharded mode
...
```