### PR TITLE
Don't create archiver threadpool on single-replset backups

### DIFF
--- a/MongoBackup/Backup.py
+++ b/MongoBackup/Backup.py
@@ -34,8 +34,8 @@ class Backup(object):
         self.dump_gzip = False
         self.balancer_wait_secs = 300
         self.balancer_sleep = 10
-        self.archiver_threads = None
-        self.resolver_threads = None
+        self.archiver_threads = 1
+        self.resolver_threads = 1
         self.notify_nsca = None
         self.nsca_server = None
         self.nsca_password = None
@@ -163,6 +163,8 @@ class Backup(object):
 
         if not self.is_mongos:
             logging.info("Starting backup of %s:%s in replset mode" % (self.host, self.port))
+
+            self.archiver_threads = 1
 
             try:
                 self.mongodumper = Mongodumper(


### PR DESCRIPTION
1. Set archiver thread pool to single-thread on replset-mode backup.
2. Set defaults for thread counts to 1 instead of None (which makes no sense).