### PR TITLE
Search for only python 2.7

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,7 +19,7 @@ if [ -z "$python_bin" ]; then
 	if [[ "`uname`" =~ "Darwin" ]]; then
 		python_bin=$(which python)
 	else
-		python_bin=$(whereis -b python | tr ' ' '\n' | egrep "/python([0-9].[0-9])?$" | head -1)
+		python_bin=$(whereis -b python | tr ' ' '\n' | egrep "/python(2\.7)?$" | head -1)
 	fi
 fi
 if [ -z "$python_bin" ]; then


### PR DESCRIPTION
If there are many pythons intalled on system this `egrep` may find for example 3.4, which this script will decline to use later. So why don't we just seach for python 2.7?
