### PR TITLE
Mcb 1.0 cleanup v2

### DIFF
--- a/mongodb_consistent_backup/Archive/Tar/Tar.py
+++ b/mongodb_consistent_backup/Archive/Tar/Tar.py
@@ -24,13 +24,17 @@ class Tar:
         self.backup_base_dir = backup_base_dir
         self.verbose         = self.config.verbose
         self.binary          = "tar"
-        self.do_gzip         = False
         self._pool           = None
 
     def compression(self, method=None):
         if method:
             self.config.archive.tar.compression = method.lower()
         return self.config.archive.tar.compression
+
+    def do_gzip(self):
+	if self.compression() == 'gzip':
+	    return True
+        return False
 
     def threads(self, thread_count=None):
         if thread_count:
@@ -55,11 +59,10 @@ class Tar:
                     subdir_name = "%s/%s" % (self.backup_base_dir, backup_dir)
                     output_file = "%s.tar" % subdir_name
 
-                    if self.compression() == 'gzip':
+                    if self.do_gzip():
                         output_file  = "%s.tgz" % subdir_name
-                        self.do_gzip = True
 
-                    self._pool.apply_async(TarThread(subdir_name, output_file, self.do_gzip, self.verbose, self.binary).run)
+                    self._pool.apply_async(TarThread(subdir_name, output_file, self.do_gzip(), self.verbose, self.binary).run)
             except Exception, e:
                 self._pool.terminate()
                 logging.fatal("Could not create archiving thread! Error: %s" % e)

--- a/mongodb_consistent_backup/Archive/Tar/Tar.py
+++ b/mongodb_consistent_backup/Archive/Tar/Tar.py
@@ -32,8 +32,8 @@ class Tar:
         return self.config.archive.tar.compression
 
     def do_gzip(self):
-	if self.compression() == 'gzip':
-	    return True
+        if self.compression() == 'gzip':
+            return True
         return False
 
     def threads(self, thread_count=None):

--- a/mongodb_consistent_backup/Archive/Tar/Tar.py
+++ b/mongodb_consistent_backup/Archive/Tar/Tar.py
@@ -29,6 +29,7 @@ class Tar:
     def compression(self, method=None):
         if method:
             self.config.archive.tar.compression = method.lower()
+            logging.info("Setting tar compression method to: %s" % self.config.archive.tar.compression)
         return self.config.archive.tar.compression
 
     def do_gzip(self):

--- a/mongodb_consistent_backup/Backup/Backup.py
+++ b/mongodb_consistent_backup/Backup/Backup.py
@@ -10,6 +10,7 @@ class Backup:
         self.secondaries   = secondaries
         self.config_server = config_server
 
+        self.method  = None
         self._method = None
         self.init()
 
@@ -17,17 +18,17 @@ class Backup:
         backup_method = self.config.backup.method
         if not backup_method or backup_method.lower() == "none":
             raise Exception, 'Must specify a backup method!', None
-        method = backup_method.lower()
-        logging.info("Using backup method: %s" % method)
+        self.method = backup_method.lower()
+        logging.info("Using backup method: %s" % self.method)
         try:
-            self._method = globals()[method.capitalize()](
+            self._method = globals()[self.method.capitalize()](
                 self.config,
                 self.backup_dir,
                 self.secondaries,
                 self.config_server
             )
         except Exception, e:
-            raise Exception, "Problem performing %s! Error: %s" % (method, e), None
+            raise Exception, "Problem performing %s! Error: %s" % (self.method, e), None
 
     def is_compressed(self):
         if self._method:

--- a/mongodb_consistent_backup/Notify/Notify.py
+++ b/mongodb_consistent_backup/Notify/Notify.py
@@ -4,6 +4,7 @@ class Notify:
     def __init__(self, config):
         self.config    = config
 
+        self.method    = None
         self._notifier = None
         self.init()
 
@@ -12,10 +13,10 @@ class Notify:
         if not notify_method or notify_method.lower() == "none":
             logging.info("Notifying disabled, skipping")
         else:
-            method = notify_method.lower()
-            logging.info("Using notify method: %s" % method)
+            self.method = notify_method.lower()
+            logging.info("Using notify method: %s" % self.method)
             try:
-                self._notifier = globals()[method.capitalize()](self.config)
+                self._notifier = globals()[self.method.capitalize()](self.config)
             except Exception, e:
                 raise e
 

--- a/mongodb_consistent_backup/Oplog/Tailer/Tailer.py
+++ b/mongodb_consistent_backup/Oplog/Tailer/Tailer.py
@@ -23,6 +23,7 @@ class Tailer:
     def compression(self, method=None):
         if method:
             self.config.oplog.compression = method.lower()
+            logging.info("Setting oplog compression method to: %s" % self.config.oplog.compression)
         return self.config.oplog.compression
 
     def do_gzip(self):

--- a/mongodb_consistent_backup/Upload/Upload.py
+++ b/mongodb_consistent_backup/Upload/Upload.py
@@ -9,6 +9,7 @@ class Upload:
         self.base_dir   = base_dir
         self.backup_dir = backup_dir
 
+        self.method    = None
         self._uploader = None
         self.init()
 
@@ -17,19 +18,16 @@ class Upload:
         if not upload_method or upload_method.lower() == "none":
             logging.info("Uploading disabled, skipping")
         else:
-            #TODO Remove this line and move to  S3 Lib for checking
-            # if self.config.upload.method == "s3" and self.config.upload.s3.bucket_name and self.config.upload.s3.bucket_prefix and self.config.upload.s3.access_key and self.config.upload.s3.secret_key:
-
-            method = upload_method.lower()
-            logging.info("Using upload method: %s" % method)
+            self.method = upload_method.lower()
+            logging.info("Using upload method: %s" % self.method)
             try:
-                self._uploader = globals()[method.capitalize()](
+                self._uploader = globals()[self.method.capitalize()](
                     self.config,
                     self.base_dir,
                     self.backup_dir
                 )
             except Exception, e:
-                raise Exception, "Problem settings up %s Uploader Error: %s" % (method, e), None
+                raise Exception, "Problem settings up %s Uploader Error: %s" % (self.method, e), None
 
     def upload(self):
         if self._uploader:


### PR DESCRIPTION
A few more code cleanup updates: added do_gzip() method to Tar to match Oplog/Tailer.py. Ensured all method-choosing submodules have a 'method' key for the chosen method (for consistency). Added extra logging.

Test run:

```
### sharded mode
+ ./bin/mongodb-consistent-backup -n test-cluster -l /opt/mongodb/backup -H localhost -P 27018
[2017-01-24 18:05:49,256] [INFO] [MainProcess] [Main:run:145] Starting mongodb-consistent-backup version 1.0.0-MCB_1.0 (git commit hash: 43230ca94a6f4132af2481f737b08d6092ab359f)
[2017-01-24 18:05:49,257] [INFO] [MainProcess] [Notify:init:14] Notifying disabled, skipping
[2017-01-24 18:05:49,257] [INFO] [MainProcess] [Archive:init:21] Using archiving method: tar
[2017-01-24 18:05:49,257] [INFO] [MainProcess] [Main:run:197] Running backup of localhost:27018 in sharded mode
[2017-01-24 18:05:49,260] [INFO] [MainProcess] [Sharding:get_start_state:42] Began with balancer state running: True
[2017-01-24 18:05:49,265] [INFO] [MainProcess] [Sharding:get_config_server:136] Found sharding config server: localhost:27019
[2017-01-24 18:05:49,273] [INFO] [MainProcess] [Replset:find_primary:76] Found PRIMARY: test1/localhost:27017 with optime Timestamp(1485270185, 1)
[2017-01-24 18:05:49,273] [INFO] [MainProcess] [Replset:find_secondary:151] Found SECONDARY test1/localhost:27027: {'priority': 1, 'lag': 0, 'optime': Timestamp(1485270185, 1), 'score': 98}
[2017-01-24 18:05:49,274] [INFO] [MainProcess] [Replset:find_secondary:161] Choosing SECONDARY localhost:27027 for replica set test1 (score: 98)
[2017-01-24 18:05:49,276] [INFO] [MainProcess] [Replset:find_primary:76] Found PRIMARY: test2/localhost:28017 with optime Timestamp(1485270185, 1)
[2017-01-24 18:05:49,277] [INFO] [MainProcess] [Replset:find_secondary:151] Found SECONDARY test2/localhost:28027: {'priority': 1, 'lag': 0, 'optime': Timestamp(1485270185, 1), 'score': 98}
[2017-01-24 18:05:49,277] [INFO] [MainProcess] [Replset:find_secondary:161] Choosing SECONDARY localhost:28027 for replica set test2 (score: 98)
[2017-01-24 18:05:49,280] [INFO] [MainProcess] [Replset:find_primary:76] Found PRIMARY: csReplSet/localhost:27019 with optime Timestamp(1485277545, 4)
[2017-01-24 18:05:49,281] [INFO] [MainProcess] [Replset:find_secondary:151] Found SECONDARY csReplSet/localhost:27029: {'priority': 1, 'configsvr': True, 'lag': 0, 'optime': Timestamp(1485277545, 4), 'score': 98}
[2017-01-24 18:05:49,281] [INFO] [MainProcess] [Replset:find_secondary:161] Choosing SECONDARY localhost:27029 for replica set csReplSet (score: 98)
[2017-01-24 18:05:49,281] [INFO] [MainProcess] [Sharding:stop_balancer:90] Stopping the balancer and waiting a max of 300 sec
[2017-01-24 18:05:52,286] [INFO] [MainProcess] [Sharding:stop_balancer:100] Balancer is now stopped
[2017-01-24 18:05:52,289] [INFO] [MainProcess] [Backup:init:22] Using backup method: mongodump
[2017-01-24 18:05:52,342] [INFO] [MainProcess] [Main:run:245] Backup method supports gzip compression, disabling compression in archive step and enabling oplog compression
[2017-01-24 18:05:52,342] [INFO] [MainProcess] [Tar:compression:32] Setting tar compression method to: none
[2017-01-24 18:05:52,343] [INFO] [MainProcess] [Tailer:compression:26] Setting oplog compression method to: gzip
[2017-01-24 18:05:52,671] [INFO] [TailerThread-1] [TailerThread:run:70] Tailing oplog on localhost:27027 for changes (gzip: True)
[2017-01-24 18:05:52,671] [INFO] [MainProcess] [Mongodump:run:127] Starting backups using mongodump 3.4.0-1.0beta (inline gzip: True, threads per dump: 1)
[2017-01-24 18:05:52,677] [INFO] [TailerThread-3] [TailerThread:run:70] Tailing oplog on localhost:27029 for changes (gzip: True)
[2017-01-24 18:05:52,681] [INFO] [MongodumpThread-6] [MongodumpThread:run:52] Starting mongodump (with oplog) backup of csReplSet/localhost:27029
[2017-01-24 18:05:52,679] [INFO] [TailerThread-2] [TailerThread:run:70] Tailing oplog on localhost:28027 for changes (gzip: True)
[2017-01-24 18:05:52,679] [INFO] [MongodumpThread-5] [MongodumpThread:run:52] Starting mongodump (with oplog) backup of test2/localhost:28027
[2017-01-24 18:05:52,682] [INFO] [MongodumpThread-4] [MongodumpThread:run:52] Starting mongodump (with oplog) backup of test1/localhost:27027
[2017-01-24 18:05:52,916] [INFO] [MongodumpThread-4] [MongodumpThread:run:94] Backup for test1/localhost:27027 completed in 0.24485206604 sec with 0 oplog changes captured to: None
[2017-01-24 18:05:52,917] [INFO] [MongodumpThread-5] [MongodumpThread:run:94] Backup for test2/localhost:28027 completed in 0.245888948441 sec with 0 oplog changes captured to: None
[2017-01-24 18:05:52,938] [INFO] [MongodumpThread-6] [MongodumpThread:run:94] Backup for csReplSet/localhost:27029 completed in 0.266765117645 sec with 0 oplog changes captured to: None
[2017-01-24 18:05:55,945] [INFO] [MainProcess] [Mongodump:wait:87] All mongodump backups completed
[2017-01-24 18:05:55,945] [INFO] [MainProcess] [Tailer:stop:59] Stopping oplog tailing threads
[2017-01-24 18:05:56,601] [INFO] [TailerThread-3] [TailerThread:run:123] Done tailing oplog on localhost:27029, 2 changes captured to: Timestamp(1485277555, 1)
[2017-01-24 18:05:56,701] [INFO] [TailerThread-1] [TailerThread:run:123] Done tailing oplog on localhost:27027, 0 changes captured to: None
[2017-01-24 18:05:56,702] [INFO] [TailerThread-2] [TailerThread:run:123] Done tailing oplog on localhost:28027, 0 changes captured to: None
[2017-01-24 18:05:56,947] [INFO] [MainProcess] [Tailer:stop:65] Stopped all oplog threads
[2017-01-24 18:05:56,947] [INFO] [MainProcess] [Sharding:restore_balancer_state:83] Restoring balancer state to: True
[2017-01-24 18:05:56,960] [INFO] [MainProcess] [Resolver:run:58] Resolving oplogs using 4 threads max
[2017-01-24 18:05:56,960] [INFO] [MainProcess] [Resolver:run:73] No oplog changes to resolve for localhost:28027
[2017-01-24 18:05:56,960] [INFO] [MainProcess] [Resolver:run:73] No oplog changes to resolve for localhost:27027
[2017-01-24 18:05:56,961] [INFO] [PoolWorker-7] [ResolverThread:run:23] Resolving oplog for host localhost:27029 to max timestamp: Timestamp(1485277555, 0)
[2017-01-24 18:05:56,962] [INFO] [PoolWorker-7] [ResolverThread:run:50] Applied 1 changes to host localhost:27029 oplog. New end timestamp: Timestamp(1485277553, 1)
[2017-01-24 18:05:57,064] [INFO] [MainProcess] [Resolver:run:108] Done resolving oplogs
[2017-01-24 18:05:57,065] [INFO] [MainProcess] [Archive:archive:43] Archiving with method: tar (options: method=tar,tar=<NestedDict ({'threads': 0, 'compression': 'none'})>)
[2017-01-24 18:05:57,071] [INFO] [MainProcess] [Tar:run:52] Archiving backup directories with pool of 2 thread(s)
[2017-01-24 18:05:57,073] [INFO] [PoolWorker-11] [TarThread:run:44] Archiving and compressing directory: /opt/mongodb/backup/test-cluster/20170124_1805/test1
[2017-01-24 18:05:57,073] [INFO] [PoolWorker-12] [TarThread:run:44] Archiving and compressing directory: /opt/mongodb/backup/test-cluster/20170124_1805/test2
[2017-01-24 18:05:57,181] [INFO] [PoolWorker-12] [TarThread:run:44] Archiving and compressing directory: /opt/mongodb/backup/test-cluster/20170124_1805/csReplSet
[2017-01-24 18:05:57,381] [INFO] [MainProcess] [Tar:run:73] Archiver threads completed
[2017-01-24 18:05:57,382] [INFO] [MainProcess] [Upload:init:19] Uploading disabled, skipping
[2017-01-24 18:05:57,382] [INFO] [MainProcess] [Main:run:313] Backup completed in 8.12864995003 sec
```

```
### replset mode
+ ./bin/mongodb-consistent-backup -n test-replset -l /opt/mongodb/backup -H localhost -P 27017
[2017-01-24 18:05:58,504] [INFO] [MainProcess] [Main:run:145] Starting mongodb-consistent-backup version 1.0.0-MCB_1.0 (git commit hash: 43230ca94a6f4132af2481f737b08d6092ab359f)
[2017-01-24 18:05:58,504] [INFO] [MainProcess] [Notify:init:14] Notifying disabled, skipping
[2017-01-24 18:05:58,504] [INFO] [MainProcess] [Archive:init:21] Using archiving method: tar
[2017-01-24 18:05:58,504] [INFO] [MainProcess] [Main:run:165] Running backup of localhost:27017 in replset mode
[2017-01-24 18:05:58,508] [INFO] [MainProcess] [Replset:find_primary:76] Found PRIMARY: test1/localhost:27017 with optime Timestamp(1485270185, 1)
[2017-01-24 18:05:58,509] [INFO] [MainProcess] [Replset:find_secondary:151] Found SECONDARY test1/localhost:27027: {'priority': 1, 'lag': 0, 'optime': Timestamp(1485270185, 1), 'score': 98}
[2017-01-24 18:05:58,509] [INFO] [MainProcess] [Replset:find_secondary:161] Choosing SECONDARY localhost:27027 for replica set test1 (score: 98)
[2017-01-24 18:05:58,509] [INFO] [MainProcess] [Backup:init:22] Using backup method: mongodump
[2017-01-24 18:05:58,550] [INFO] [MainProcess] [Mongodump:run:127] Starting backups using mongodump 3.4.0-1.0beta (inline gzip: True, threads per dump: 2)
[2017-01-24 18:05:58,553] [INFO] [MongodumpThread-1] [MongodumpThread:run:52] Starting mongodump (with oplog) backup of test1/localhost:27027
[2017-01-24 18:05:58,792] [INFO] [MongodumpThread-1] [MongodumpThread:run:94] Backup for test1/localhost:27027 completed in 0.242156028748 sec with 0 oplog changes captured to: None
[2017-01-24 18:06:01,799] [INFO] [MainProcess] [Mongodump:wait:87] All mongodump backups completed
[2017-01-24 18:06:01,821] [INFO] [MainProcess] [Main:run:189] Backup method supports gzip compression, disabling compression in archive step
[2017-01-24 18:06:01,821] [INFO] [MainProcess] [Tar:compression:32] Setting tar compression method to: none
[2017-01-24 18:06:01,821] [INFO] [MainProcess] [Tar:threads:43] Setting tar thread count to: 1
[2017-01-24 18:06:01,821] [INFO] [MainProcess] [Archive:archive:43] Archiving with method: tar (options: method=tar,tar=<NestedDict ({'threads': 1, 'compression': 'none'})>)
[2017-01-24 18:06:01,826] [INFO] [MainProcess] [Tar:run:52] Archiving backup directories with pool of 1 thread(s)
[2017-01-24 18:06:01,827] [INFO] [PoolWorker-2] [TarThread:run:44] Archiving and compressing directory: /opt/mongodb/backup/test-replset/20170124_1805/test1
[2017-01-24 18:06:02,031] [INFO] [MainProcess] [Tar:run:73] Archiver threads completed
[2017-01-24 18:06:02,031] [INFO] [MainProcess] [Upload:init:19] Uploading disabled, skipping
[2017-01-24 18:06:02,032] [INFO] [MainProcess] [Main:run:313] Backup completed in 3.53083705902 sec
```