### PR TITLE
Mcb 1.0 cleanup v4

### DIFF
--- a/mongodb_consistent_backup/Archive/Archive.py
+++ b/mongodb_consistent_backup/Archive/Archive.py
@@ -1,7 +1,7 @@
 import logging
 
 from Tar import Tar
-from mongodb_consistent_backup.Common import config_to_string, parse_submodule
+from mongodb_consistent_backup.Common import config_to_string, parse_method
 
 
 class Archive:
@@ -15,10 +15,10 @@ class Archive:
 
     def init(self):
         archive_method = self.config.archive.method
-        if not archive_method or parse_submodule(archive_method) == "none":
+        if not archive_method or parse_method(archive_method) == "none":
             logging.info("Archiving disabled, skipping")
         else:
-            self.method = parse_submodule(archive_method)
+            self.method = parse_method(archive_method)
             logging.info("Using archiving method: %s" % self.method)
             try:
                 self._archiver = globals()[self.method.capitalize()](

--- a/mongodb_consistent_backup/Archive/Tar/Tar.py
+++ b/mongodb_consistent_backup/Archive/Tar/Tar.py
@@ -6,6 +6,7 @@ from multiprocessing import Pool, cpu_count
 from types import MethodType
 
 from TarThread import TarThread
+from mongodb_consistent_backup.Common import parse_method
 
 
 # Allows pooled .apply_async()s to work on Class-methods:
@@ -28,9 +29,9 @@ class Tar:
 
     def compression(self, method=None):
         if method:
-            self.config.archive.tar.compression = method.lower()
+            self.config.archive.tar.compression = parse_method(method)
             logging.info("Setting tar compression method to: %s" % self.config.archive.tar.compression)
-        return self.config.archive.tar.compression
+        return parse_method(self.config.archive.tar.compression)
 
     def do_gzip(self):
         if self.compression() == 'gzip':

--- a/mongodb_consistent_backup/Backup/Backup.py
+++ b/mongodb_consistent_backup/Backup/Backup.py
@@ -1,7 +1,7 @@
 import logging
 
 from Mongodump import Mongodump
-from mongodb_consistent_backup.Common import config_to_string, parse_submodule
+from mongodb_consistent_backup.Common import config_to_string, parse_method
 
 
 class Backup:
@@ -17,9 +17,9 @@ class Backup:
 
     def init(self):
         backup_method = self.config.backup.method
-        if not backup_method or parse_submodule(backup_method) == "none":
+        if not backup_method or parse_method(backup_method) == "none":
             raise Exception, 'Must specify a backup method!', None
-        self.method   = parse_submodule(backup_method)
+        self.method   = parse_method(backup_method)
         config_string = config_to_string(self.config.backup[self.method])
         logging.info("Using backup method: %s (options: %s)" % (self.method, config_string))
         try:

--- a/mongodb_consistent_backup/Common/DB.py
+++ b/mongodb_consistent_backup/Common/DB.py
@@ -72,5 +72,5 @@ class DB:
         return self._conn
 
     def close(self):
-	if self._conn:
+        if self._conn:
             return self._conn.close()

--- a/mongodb_consistent_backup/Common/DB.py
+++ b/mongodb_consistent_backup/Common/DB.py
@@ -72,4 +72,5 @@ class DB:
         return self._conn
 
     def close(self):
-        return self._conn.close()
+	if self._conn:
+            return self._conn.close()

--- a/mongodb_consistent_backup/Common/Util.py
+++ b/mongodb_consistent_backup/Common/Util.py
@@ -1,13 +1,14 @@
 import socket
 
+
 def config_to_string(config):
     config_vars = ""
     for key in config:
         config_vars += "%s=%s," % (key, config[key])
     return config_vars[:-1]
 
-def parse_submodule(name):
-    return name.rstrip().lower()
+def parse_method(method):
+    return method.rstrip().lower()
 
 def validate_hostname(hostname):
     try:

--- a/mongodb_consistent_backup/Common/__init__.py
+++ b/mongodb_consistent_backup/Common/__init__.py
@@ -2,4 +2,4 @@ from Config import Config
 from DB import DB
 from LocalCommand import LocalCommand
 from Lock import Lock
-from Util import config_to_string, parse_submodule, validate_hostname 
+from Util import config_to_string, parse_method, validate_hostname 

--- a/mongodb_consistent_backup/Main.py
+++ b/mongodb_consistent_backup/Main.py
@@ -8,7 +8,7 @@ from time import time
 
 from Archive import Archive
 from Backup import Backup
-from Common import DB, Lock, validate_hostname
+from Common import Config, DB, Lock, validate_hostname
 from Notify import Notify
 from Oplog import Tailer, Resolver
 from Replication import Replset, ReplsetSharded
@@ -17,37 +17,44 @@ from Upload import Upload
 
 
 class MongodbConsistentBackup(object):
-    def __init__(self, config, prog_name="mongodb-consistent-backup"):
-        self.config          = config
-        self.program_name    = prog_name
-        self.backup          = None
-        self.archive         = None
-        self.sharding        = None
-        self.replset         = None
-        self.replset_sharded = None
-        self.notify          = None
-        self.oplogtailer     = None
-        self.oplog_resolver  = None
-        self.upload          = None
-        self.lock            = None
-        self.start_time      = time()
-        self.end_time        = None
-        self.backup_duration = None
-        self.backup_time = None
-        self.backup_root_directory = None
+    def __init__(self, prog_name="mongodb-consistent-backup"):
+        self.program_name             = prog_name
+        self.backup                   = None
+        self.archive                  = None
+        self.sharding                 = None
+        self.replset                  = None
+        self.replset_sharded          = None
+        self.notify                   = None
+        self.oplogtailer              = None
+        self.oplog_resolver           = None
+        self.upload                   = None
+        self.lock                     = None
+        self.start_time               = time()
+        self.end_time                 = None
+        self.backup_duration          = None
+        self.backup_time              = None
+        self.backup_root_directory    = None
         self.backup_root_subdirectory = None
-        self.connection      = None
-        self.db              = None
-        self.is_sharded      = False
-        self.secondaries     = {}
-        self.oplog_summary   = {}
-        self.backup_summary  = {}
-        self.log_level = None
+        self.connection               = None
+        self.db                       = None
+        self.is_sharded               = False
+        self.secondaries              = {}
+        self.oplog_summary            = {}
+        self.backup_summary           = {}
+        self.log_level                = None
 
+        self.setup_config()
         self.setup_signal_handlers()
         self.setup_logger()
         self.set_backup_dirs()
         self.get_db_conn()
+
+    def setup_config(self):
+        try:
+            self.config = Config()
+        except Exception, e:
+            print "Error setting up configuration: '%s'!" % e
+            sys.exit(1)
 
     def setup_logger(self):
         self.log_level = logging.INFO

--- a/mongodb_consistent_backup/Main.py
+++ b/mongodb_consistent_backup/Main.py
@@ -157,7 +157,7 @@ class MongodbConsistentBackup(object):
         try:
             self.notify = Notify(self.config)
         except Exception, e:
-            raise e
+            self.exception("Problem starting notifier! Error: %s" % e)
 
         # Setup the archiver
         try:
@@ -166,7 +166,17 @@ class MongodbConsistentBackup(object):
                 self.backup_root_directory, 
             )
         except Exception, e:
-            raise e
+            self.exception("Problem starting archiver! Error: %s" % e)
+
+        # Setup the uploader
+        try:
+            self.upload = Upload(
+                self.config,
+                self.backup_root_directory,
+                self.backup_root_subdirectory
+            )
+        except Exception, e:
+            self.exception("Problem starting uploader! Error: %s" % e)
 
         if not self.is_sharded:
             logging.info("Running backup of %s:%s in replset mode" % (self.config.host, self.config.port))
@@ -293,11 +303,6 @@ class MongodbConsistentBackup(object):
 
         # upload backup
         try:
-            self.upload = Upload(
-                self.config,
-                self.backup_root_directory,
-                self.backup_root_subdirectory
-            )
             self.upload.upload()
         except Exception, e:
             self.exception("Problem performing upload of backup! Error: %s" % e)

--- a/mongodb_consistent_backup/Notify/Notify.py
+++ b/mongodb_consistent_backup/Notify/Notify.py
@@ -1,6 +1,6 @@
 import logging
 
-from mongodb_consistent_backup.Common import config_to_string, parse_submodule
+from mongodb_consistent_backup.Common import config_to_string, parse_method
 
 
 class Notify:
@@ -13,10 +13,10 @@ class Notify:
 
     def init(self):
         notify_method = self.config.notify.method
-        if not notify_method or parse_submodule(notify_method) == "none":
+        if not notify_method or parse_method(notify_method) == "none":
             logging.info("Notifying disabled, skipping")
         else:
-            self.method   = parse_submodule(notify_method)
+            self.method   = parse_method(notify_method)
             config_string = config_to_string(self.config.notify[self.method])
             logging.info("Using notify method: %s (options: %s)" % (self.method, config_string))
             try:

--- a/mongodb_consistent_backup/Oplog/Tailer/Tailer.py
+++ b/mongodb_consistent_backup/Oplog/Tailer/Tailer.py
@@ -4,6 +4,7 @@ from multiprocessing import Queue
 from time import sleep
 
 from TailerThread import TailerThread
+from mongodb_consistent_backup.Common import parse_method
 
 
 class Tailer:
@@ -22,9 +23,9 @@ class Tailer:
 
     def compression(self, method=None):
         if method:
-            self.config.oplog.compression = method.lower()
+            self.config.oplog.compression = parse_method(method)
             logging.info("Setting oplog compression method to: %s" % self.config.oplog.compression)
-        return self.config.oplog.compression
+        return parse_method(self.config.oplog.compression)
 
     def do_gzip(self):
         if self.compression() == 'gzip':

--- a/mongodb_consistent_backup/Upload/Upload.py
+++ b/mongodb_consistent_backup/Upload/Upload.py
@@ -1,7 +1,7 @@
 import logging
 
 from S3 import S3
-from mongodb_consistent_backup.Common import config_to_string, parse_submodule
+from mongodb_consistent_backup.Common import config_to_string, parse_method
 
 
 class Upload:
@@ -16,10 +16,10 @@ class Upload:
 
     def init(self):
         upload_method = self.config.upload.method
-        if not upload_method or parse_submodule(upload_method) == "none":
+        if not upload_method or parse_method(upload_method) == "none":
             logging.info("Uploading disabled, skipping")
         else:
-            self.method   = parse_submodule(upload_method)
+            self.method   = parse_method(upload_method)
             config_string = config_to_string(self.config.upload[self.method])
             logging.info("Using upload method: %s (options: %s)" % (self.method, config_string))
             try:

--- a/mongodb_consistent_backup/__init__.py
+++ b/mongodb_consistent_backup/__init__.py
@@ -1,24 +1,12 @@
-# TODO-timv Can we remove this?
-import os
 import sys
 
-from Common import Config
 from Main import MongodbConsistentBackup
-
-__version__ = '#.#.#'
-git_commit  = 'GIT_COMMIT_HASH'
 
 
 # noinspection PyUnusedLocal
 def run():
     try:
-        config = Config()
-    except Exception, e:
-        print "Error setting up configuration: '%s'!" % e
-        sys.exit(1)
-
-    try:
-        MongodbConsistentBackup(config).run()
+        MongodbConsistentBackup().run()
     except Exception, e:
         # noinspection PyUnusedLocal
         print "Backup '%s' failed for mongodb instance %s:%s : %s" % (config.name, config.host, config.port, e)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -66,7 +66,6 @@ if [ -d ${srcdir} ]; then
 			exit 1
 		else
 			sed -i -e s@\#.\#.\#@${version}@g ${builddir}/setup.py
-			sed -i -e s@\#.\#.\#@${version}@g ${builddir}/${mod_name}/__init__.py
 			sed -i -e s@\#.\#.\#@${version}@g ${builddir}/${mod_name}/Common/Config.py
 		fi
 	else
@@ -78,7 +77,6 @@ if [ -d ${srcdir} ]; then
 	if [ -z "$git_commit" ]; then
 		echo "Warning: cannot find git commit hash!"
 	else
-		sed -i -e s@GIT_COMMIT_HASH@${git_commit}@g ${builddir}/${mod_name}/__init__.py
 		sed -i -e s@GIT_COMMIT_HASH@${git_commit}@g ${builddir}/${mod_name}/Common/Config.py
 	fi
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -97,7 +97,7 @@ if [ -d ${srcdir} ]; then
 	if [ ! -d ${pexdir} ]; then
 		mkdir -p ${pexdir}
 	else
-		rm -f ${pexdir}/build/mongodb_consistent_backup-* 
+		rm -f ${pexdir}/build/mongodb_consistent_backup-*.whl 
 	fi
 	[ ! -d ${bindir} ] && mkdir -p ${bindir}
 	${venvdir}/bin/python2.7 ${venvdir}/bin/pex -o ${output_file} -m ${mod_name} -r ${require_file} --pex-root=${pexdir}  ${builddir}


### PR DESCRIPTION
1. Start uploader earlier in Main.py. This is for future plans of uploading earlier.
2. Rename mongodb_consistent_backup.Common parse_submodule to parse_method.
3. Use parse_method() to cleanup method names wherever they're set.
4. Trimmed-down __init__.py to do as little as possible. Remove unused imports and vars.

```
### sharded mode
+ ./bin/mongodb-consistent-backup -n test-cluster -l /opt/mongodb/backup -H localhost -P 27018
[2017-01-25 15:43:07,046] [INFO] [MainProcess] [Main:run:152] Starting mongodb-consistent-backup version 1.0.0-MCB_1.0 (git commit hash: 1012e34cc4ae97fa8d03a469d84919718a1d7d51)
[2017-01-25 15:43:07,046] [INFO] [MainProcess] [Notify:init:17] Notifying disabled, skipping
[2017-01-25 15:43:07,047] [INFO] [MainProcess] [Archive:init:22] Using archiving method: tar
[2017-01-25 15:43:07,047] [INFO] [MainProcess] [Upload:init:20] Uploading disabled, skipping
[2017-01-25 15:43:07,048] [INFO] [MainProcess] [Main:run:214] Running backup of localhost:27018 in sharded mode
[2017-01-25 15:43:07,051] [INFO] [MainProcess] [Sharding:get_start_state:42] Began with balancer state running: True
[2017-01-25 15:43:07,056] [INFO] [MainProcess] [Sharding:get_config_server:136] Found sharding config server: localhost:27019
[2017-01-25 15:43:07,063] [INFO] [MainProcess] [Replset:find_primary:76] Found PRIMARY: test1/localhost:27027 with optime Timestamp(1485346358, 1)
[2017-01-25 15:43:07,064] [INFO] [MainProcess] [Replset:find_secondary:151] Found SECONDARY test1/localhost:27017: {'priority': 1, 'lag': 0, 'optime': Timestamp(1485346358, 1), 'score': 98}
[2017-01-25 15:43:07,064] [INFO] [MainProcess] [Replset:find_secondary:161] Choosing SECONDARY localhost:27017 for replica set test1 (score: 98)
[2017-01-25 15:43:07,068] [INFO] [MainProcess] [Replset:find_primary:76] Found PRIMARY: test2/localhost:28027 with optime Timestamp(1485346358, 1)
[2017-01-25 15:43:07,069] [INFO] [MainProcess] [Replset:find_secondary:151] Found SECONDARY test2/localhost:28017: {'priority': 1, 'lag': 0, 'optime': Timestamp(1485346358, 1), 'score': 98}
[2017-01-25 15:43:07,069] [INFO] [MainProcess] [Replset:find_secondary:161] Choosing SECONDARY localhost:28017 for replica set test2 (score: 98)
[2017-01-25 15:43:07,071] [INFO] [MainProcess] [Replset:find_primary:76] Found PRIMARY: csReplSet/localhost:27029 with optime Timestamp(1485355377, 4)
[2017-01-25 15:43:07,072] [INFO] [MainProcess] [Replset:find_secondary:151] Found SECONDARY csReplSet/localhost:27019: {'priority': 1, 'configsvr': True, 'lag': 0, 'optime': Timestamp(1485355377, 4), 'score': 98}
[2017-01-25 15:43:07,072] [INFO] [MainProcess] [Replset:find_secondary:161] Choosing SECONDARY localhost:27019 for replica set csReplSet (score: 98)
[2017-01-25 15:43:07,072] [INFO] [MainProcess] [Sharding:stop_balancer:90] Stopping the balancer and waiting a max of 300 sec
[2017-01-25 15:43:10,078] [INFO] [MainProcess] [Sharding:stop_balancer:100] Balancer is now stopped
[2017-01-25 15:43:10,081] [INFO] [MainProcess] [Backup:init:24] Using backup method: mongodump (options: binary=/usr/bin/mongodump,compression=gzip)
[2017-01-25 15:43:10,138] [INFO] [MainProcess] [Main:run:262] Backup method supports gzip compression, disabling compression in archive step and enabling oplog compression
[2017-01-25 15:43:10,138] [INFO] [MainProcess] [Tar:compression:33] Setting tar compression method to: none
[2017-01-25 15:43:10,138] [INFO] [MainProcess] [Tailer:compression:27] Setting oplog compression method to: gzip
[2017-01-25 15:43:10,475] [INFO] [TailerThread-1] [TailerThread:run:70] Tailing oplog on localhost:27017 for changes (gzip: True)
[2017-01-25 15:43:10,475] [INFO] [MainProcess] [Mongodump:run:127] Starting backups using mongodump 3.4.0-1.0beta (inline gzip: True, threads per dump: 1)
[2017-01-25 15:43:10,480] [INFO] [TailerThread-3] [TailerThread:run:70] Tailing oplog on localhost:27019 for changes (gzip: True)
[2017-01-25 15:43:10,483] [INFO] [TailerThread-2] [TailerThread:run:70] Tailing oplog on localhost:28017 for changes (gzip: True)
[2017-01-25 15:43:10,485] [INFO] [MongodumpThread-5] [MongodumpThread:run:52] Starting mongodump (with oplog) backup of test2/localhost:28017
[2017-01-25 15:43:10,486] [INFO] [MongodumpThread-4] [MongodumpThread:run:52] Starting mongodump (with oplog) backup of test1/localhost:27017
[2017-01-25 15:43:10,485] [INFO] [MongodumpThread-6] [MongodumpThread:run:52] Starting mongodump (with oplog) backup of csReplSet/localhost:27019
[2017-01-25 15:43:10,722] [INFO] [MongodumpThread-4] [MongodumpThread:run:94] Backup for test1/localhost:27017 completed in 0.247344970703 sec with 0 oplog changes captured to: None
[2017-01-25 15:43:10,726] [INFO] [MongodumpThread-5] [MongodumpThread:run:94] Backup for test2/localhost:28017 completed in 0.251133918762 sec with 0 oplog changes captured to: None
[2017-01-25 15:43:10,755] [INFO] [MongodumpThread-6] [MongodumpThread:run:94] Backup for csReplSet/localhost:27019 completed in 0.279780864716 sec with 0 oplog changes captured to: None
[2017-01-25 15:43:13,766] [INFO] [MainProcess] [Mongodump:wait:87] All mongodump backups completed
[2017-01-25 15:43:13,766] [INFO] [MainProcess] [Tailer:stop:60] Stopping oplog tailing threads
[2017-01-25 15:43:14,505] [INFO] [TailerThread-1] [TailerThread:run:123] Done tailing oplog on localhost:27017, 0 changes captured to: None
[2017-01-25 15:43:14,512] [INFO] [TailerThread-2] [TailerThread:run:123] Done tailing oplog on localhost:28017, 0 changes captured to: None
[2017-01-25 15:43:14,518] [INFO] [TailerThread-3] [TailerThread:run:123] Done tailing oplog on localhost:27019, 0 changes captured to: None
[2017-01-25 15:43:14,769] [INFO] [MainProcess] [Tailer:stop:66] Stopped all oplog threads
[2017-01-25 15:43:14,770] [INFO] [MainProcess] [Sharding:restore_balancer_state:83] Restoring balancer state to: True
[2017-01-25 15:43:14,782] [INFO] [MainProcess] [Resolver:run:58] Resolving oplogs using 4 threads max
[2017-01-25 15:43:14,782] [INFO] [MainProcess] [Resolver:run:73] No oplog changes to resolve for localhost:27017
[2017-01-25 15:43:14,783] [INFO] [MainProcess] [Resolver:run:73] No oplog changes to resolve for localhost:27019
[2017-01-25 15:43:14,783] [INFO] [MainProcess] [Resolver:run:73] No oplog changes to resolve for localhost:28017
[2017-01-25 15:43:14,886] [INFO] [MainProcess] [Resolver:run:108] Done resolving oplogs
[2017-01-25 15:43:14,886] [INFO] [MainProcess] [Archive:archive:44] Archiving with method: tar (options: threads=0,compression=none)
[2017-01-25 15:43:14,892] [INFO] [MainProcess] [Tar:run:53] Archiving backup directories with pool of 2 thread(s)
[2017-01-25 15:43:14,894] [INFO] [PoolWorker-11] [TarThread:run:44] Archiving and compressing directory: /opt/mongodb/backup/test-cluster/20170125_1543/test1
[2017-01-25 15:43:14,896] [INFO] [PoolWorker-12] [TarThread:run:44] Archiving and compressing directory: /opt/mongodb/backup/test-cluster/20170125_1543/test2
[2017-01-25 15:43:14,999] [INFO] [PoolWorker-11] [TarThread:run:44] Archiving and compressing directory: /opt/mongodb/backup/test-cluster/20170125_1543/csReplSet
[2017-01-25 15:43:15,199] [INFO] [MainProcess] [Tar:run:74] Archiver threads completed
[2017-01-25 15:43:15,200] [INFO] [MainProcess] [Main:run:325] Backup completed in 8.166410923 sec
```

```
### replset mode
+ ./bin/mongodb-consistent-backup -n test-replset -l /opt/mongodb/backup -H localhost -P 27017
[2017-01-25 15:43:16,299] [INFO] [MainProcess] [Main:run:152] Starting mongodb-consistent-backup version 1.0.0-MCB_1.0 (git commit hash: 1012e34cc4ae97fa8d03a469d84919718a1d7d51)
[2017-01-25 15:43:16,300] [INFO] [MainProcess] [Notify:init:17] Notifying disabled, skipping
[2017-01-25 15:43:16,300] [INFO] [MainProcess] [Archive:init:22] Using archiving method: tar
[2017-01-25 15:43:16,300] [INFO] [MainProcess] [Upload:init:20] Uploading disabled, skipping
[2017-01-25 15:43:16,300] [INFO] [MainProcess] [Main:run:182] Running backup of localhost:27017 in replset mode
[2017-01-25 15:43:16,304] [INFO] [MainProcess] [Replset:find_primary:76] Found PRIMARY: test1/localhost:27027 with optime Timestamp(1485346358, 1)
[2017-01-25 15:43:16,304] [INFO] [MainProcess] [Replset:find_secondary:151] Found SECONDARY test1/localhost:27017: {'priority': 1, 'lag': 0, 'optime': Timestamp(1485346358, 1), 'score': 98}
[2017-01-25 15:43:16,305] [INFO] [MainProcess] [Replset:find_secondary:161] Choosing SECONDARY localhost:27017 for replica set test1 (score: 98)
[2017-01-25 15:43:16,305] [INFO] [MainProcess] [Backup:init:24] Using backup method: mongodump (options: binary=/usr/bin/mongodump,compression=gzip)
[2017-01-25 15:43:16,346] [INFO] [MainProcess] [Mongodump:run:127] Starting backups using mongodump 3.4.0-1.0beta (inline gzip: True, threads per dump: 2)
[2017-01-25 15:43:16,349] [INFO] [MongodumpThread-1] [MongodumpThread:run:52] Starting mongodump (with oplog) backup of test1/localhost:27017
[2017-01-25 15:43:16,588] [INFO] [MongodumpThread-1] [MongodumpThread:run:94] Backup for test1/localhost:27017 completed in 0.241311073303 sec with 0 oplog changes captured to: None
[2017-01-25 15:43:19,599] [INFO] [MainProcess] [Mongodump:wait:87] All mongodump backups completed
[2017-01-25 15:43:19,621] [INFO] [MainProcess] [Main:run:206] Backup method supports gzip compression, disabling compression in archive step
[2017-01-25 15:43:19,621] [INFO] [MainProcess] [Tar:compression:33] Setting tar compression method to: none
[2017-01-25 15:43:19,621] [INFO] [MainProcess] [Tar:threads:44] Setting tar thread count to: 1
[2017-01-25 15:43:19,621] [INFO] [MainProcess] [Archive:archive:44] Archiving with method: tar (options: threads=1,compression=none)
[2017-01-25 15:43:19,626] [INFO] [MainProcess] [Tar:run:53] Archiving backup directories with pool of 1 thread(s)
[2017-01-25 15:43:19,628] [INFO] [PoolWorker-2] [TarThread:run:44] Archiving and compressing directory: /opt/mongodb/backup/test-replset/20170125_1543/test1
[2017-01-25 15:43:19,828] [INFO] [MainProcess] [Tar:run:74] Archiver threads completed
[2017-01-25 15:43:19,829] [INFO] [MainProcess] [Main:run:325] Backup completed in 3.53995203972 sec
```