### PR TITLE
Mcb 1.0 cleanup v6

### DIFF
--- a/mongodb_consistent_backup/Archive/Archive.py
+++ b/mongodb_consistent_backup/Archive/Archive.py
@@ -1,7 +1,7 @@
 import logging
 
 from Tar import Tar
-from mongodb_consistent_backup.Common import config_to_string, parse_method
+from mongodb_consistent_backup.Common import Timer, config_to_string, parse_method
 
 
 class Archive:
@@ -11,6 +11,7 @@ class Archive:
 
         self.method    = None
         self._archiver = None
+        self.timer     = Timer()
         self.init()
 
     def init(self):
@@ -42,7 +43,12 @@ class Archive:
         if self._archiver:
             config_string = config_to_string(self.config.archive[self.method])
             logging.info("Archiving with method: %s (options: %s)" % (self.method, config_string))
-            return self._archiver.run()
+            self.timer.start()
+
+            self._archiver.run()
+
+            self.timer.stop()
+            logging.info("Archiving completed in %s seconds" % self.timer.duration())
 
     def close(self):
         if self._archiver:

--- a/mongodb_consistent_backup/Archive/Tar/Tar.py
+++ b/mongodb_consistent_backup/Archive/Tar/Tar.py
@@ -67,15 +67,14 @@ class Tar:
                     self._pool.apply_async(TarThread(subdir_name, output_file, self.do_gzip(), self.verbose, self.binary).run)
             except Exception, e:
                 self._pool.terminate()
-                logging.fatal("Could not create archiving thread! Error: %s" % e)
+                logging.fatal("Could not create tar archiving thread! Error: %s" % e)
                 raise e
             self._pool.close()
             self._pool.join()
-        logging.info("Archiver threads completed")
 
     def close(self):
-        logging.debug("Stopping Archiver threads")
+        logging.debug("Stopping tar archiving threads")
         if self._pool is not None:
             self._pool.terminate()
             self._pool.join()
-        logging.info("Stopped all Archiver threads")
+        logging.info("Stopped all tar archiving threads")

--- a/mongodb_consistent_backup/Archive/Tar/__init__.py
+++ b/mongodb_consistent_backup/Archive/Tar/__init__.py
@@ -3,7 +3,7 @@ from Tar import Tar
 
 def config(parser):
     parser.add_argument("--archive.tar.compression", dest="archive.tar.compression",
-                        help="Archiver compression method (default: gzip)", default='gzip', choices=['gzip', 'none'])
+                        help="Tar archiver compression method (default: gzip)", default='gzip', choices=['gzip', 'none'])
     parser.add_argument("--archive.tar.threads", dest="archive.tar.threads", 
-                        help="Number of threads to use in archive phase (default: 1-per-CPU)", default=0, type=int)
+                        help="Number of Tar archiver threads to use (default: 1-per-CPU)", default=0, type=int)
     return parser

--- a/mongodb_consistent_backup/Common/Config.py
+++ b/mongodb_consistent_backup/Common/Config.py
@@ -1,3 +1,4 @@
+import mongodb_consistent_backup
 import sys
 
 from argparse import Action
@@ -71,7 +72,7 @@ class Config(object):
             return data[keys]
 
     def parse_submodules(self):
-        for _, modname, ispkg in walk_packages(path="."):
+        for _, modname, ispkg in walk_packages(path=mongodb_consistent_backup.__path__, prefix=mongodb_consistent_backup.__name__+'.'):
             if ispkg:
                 try:
                     components = modname.split('.')

--- a/mongodb_consistent_backup/Common/Timer.py
+++ b/mongodb_consistent_backup/Common/Timer.py
@@ -1,0 +1,25 @@
+from time import time
+
+
+class Timer:
+    def __init__(self):
+        self.count  = 0
+        self.rounds = {}
+
+    def start(self):
+        self.count += 1
+        self.rounds[self.count] = { 'start': time(), 'started': True }
+
+    def stop(self):
+        if self.rounds[self.count] and self.rounds[self.count]['started']:
+            self.rounds[self.count]['started'] = False
+            self.rounds[self.count]['end']     = time()
+
+    def duration(self):
+        if 'start' in self.rounds[self.count]:
+            if 'end' in self.rounds[self.count]:
+                end = self.rounds[self.count]['end']
+            else:
+                end = time()
+            return end - self.rounds[self.count]['start']
+        return -1

--- a/mongodb_consistent_backup/Common/__init__.py
+++ b/mongodb_consistent_backup/Common/__init__.py
@@ -2,4 +2,5 @@ from Config import Config
 from DB import DB
 from LocalCommand import LocalCommand
 from Lock import Lock
+from Timer import Timer
 from Util import config_to_string, parse_method, validate_hostname 

--- a/mongodb_consistent_backup/Main.py
+++ b/mongodb_consistent_backup/Main.py
@@ -4,11 +4,10 @@ import logging
 from datetime import datetime
 from multiprocessing import current_process
 from signal import signal, SIGINT, SIGTERM
-from time import time
 
 from Archive import Archive
 from Backup import Backup
-from Common import Config, DB, Lock, validate_hostname
+from Common import Config, DB, Lock, Timer, validate_hostname
 from Notify import Notify
 from Oplog import Tailer, Resolver
 from Replication import Replset, ReplsetSharded
@@ -29,18 +28,16 @@ class MongodbConsistentBackup(object):
         self.oplog_resolver           = None
         self.upload                   = None
         self.lock                     = None
-        self.start_time               = time()
-        self.end_time                 = None
-        self.backup_duration          = None
         self.backup_time              = None
         self.backup_root_directory    = None
         self.backup_root_subdirectory = None
         self.db                       = None
         self.is_sharded               = False
+        self.log_level                = None
+        self.timer                    = Timer()
         self.secondaries              = {}
         self.oplog_summary            = {}
         self.backup_summary           = {}
-        self.log_level                = None
 
         self.setup_config()
         self.setup_logger()
@@ -149,6 +146,7 @@ class MongodbConsistentBackup(object):
         logging.info("Starting %s version %s (git commit hash: %s)" % (self.program_name, self.config.version, self.config.git_commit))
 
         self.get_lock()
+        self.timer.start()
 
         # Setup the notifier
         try:
@@ -285,8 +283,9 @@ class MongodbConsistentBackup(object):
                 self.exception("Problem restoring balancer lock! Error: %s" % e)
 
             # resolve/merge tailed oplog into mongodump oplog.bson to a consistent point for all shards
-            if self.config.backup.method == "mongodump" and self.oplogtailer:
+            if self.backup.method == "mongodump" and self.oplogtailer:
                 self.oplog_resolver = Resolver(self.config, self.oplog_summary, self.backup_summary)
+                self.oplog_resolver.compression(self.oplogtailer.compression())
                 self.oplog_resolver.run()
 
         # archive backup directories
@@ -295,21 +294,20 @@ class MongodbConsistentBackup(object):
         except Exception, e:
             self.exception("Problem performing archiving! Error: %s" % e)
 
-        self.end_time = time()
-        self.backup_duration = self.end_time - self.start_time
-
         # upload backup
         try:
             self.upload.upload()
         except Exception, e:
             self.exception("Problem performing upload of backup! Error: %s" % e)
 
+        self.timer.stop()
+
         # send notifications of backup state
         try:
             self.notify.notify("%s: backup '%s' succeeded in %s secs" % (
                 self.program_name,
                 self.config.backup.name,
-                self.backup_duration
+                self.timer.duration()
             ), True)
         except Exception, e:
             self.exception("Problem running Notifier! Error: %s" % e)
@@ -319,4 +317,4 @@ class MongodbConsistentBackup(object):
 
         self.release_lock()
 
-        logging.info("Backup completed in %s sec" % self.backup_duration)
+        logging.info("Completed %s in %s sec" % (self.program_name, self.timer.duration()))

--- a/mongodb_consistent_backup/Oplog/Resolver/Resolver.py
+++ b/mongodb_consistent_backup/Oplog/Resolver/Resolver.py
@@ -44,7 +44,7 @@ class Resolver:
             self.config.oplog.compression = parse_method(method)
         return parse_method(self.config.oplog.compression)
 
-    def is_gzip(self):
+    def do_gzip(self):
         if self.compression() == 'gzip':
            return True
         return False
@@ -97,7 +97,7 @@ class Resolver:
                                 backup_oplog['file'],
                                 backup_oplog['last_ts'],
                                 self.end_ts,
-                                self.is_gzip()
+                                self.do_gzip()
                             ).run)
                         except Exception, e:
                             logging.fatal("Resolve failed for %s:%s! Error: %s" % (host, port, e))

--- a/mongodb_consistent_backup/Oplog/Resolver/Resolver.py
+++ b/mongodb_consistent_backup/Oplog/Resolver/Resolver.py
@@ -68,7 +68,7 @@ class Resolver:
 
     def run(self):
         logging.info("Resolving oplogs using %i threads max" % self.threads())
-	self.timer.start()
+        self.timer.start()
 
         self.end_ts   = self.get_consistent_end_ts()
         for host in self.backup_oplogs:

--- a/mongodb_consistent_backup/Upload/S3/S3.py
+++ b/mongodb_consistent_backup/Upload/S3/S3.py
@@ -24,6 +24,7 @@ class S3:
         self.config          = config
         self.source_dir      = source_dir
         self.key_prefix      = key_prefix
+        self.remove_uploaded = self.config.upload.remove_uploaded
         self.s3_host         = self.config.upload.s3.host
         self.bucket_name     = self.config.upload.s3.bucket_name
         self.bucket_prefix   = self.config.upload.s3.bucket_prefix
@@ -31,7 +32,6 @@ class S3:
         self.secret_key      = self.config.upload.s3.secret_key
         self.thread_count    = self.config.upload.s3.threads
         self.chunk_size_mb   = self.config.upload.s3.chunk_size_mb
-        self.remove_uploaded = self.config.upload.remove_uploaded
         self.chunk_size      = self.chunk_size_mb * 1024 * 1024
 
         self._pool        = None

--- a/mongodb_consistent_backup/Upload/S3/S3.py
+++ b/mongodb_consistent_backup/Upload/S3/S3.py
@@ -29,15 +29,15 @@ class S3:
         self.bucket_prefix   = self.config.upload.s3.bucket_prefix
         self.access_key      = self.config.upload.s3.access_key
         self.secret_key      = self.config.upload.s3.secret_key
-        self.remove_uploaded = self.config.upload.s3.remove_uploaded
         self.thread_count    = self.config.upload.s3.threads
         self.chunk_size_mb   = self.config.upload.s3.chunk_size_mb
+        self.remove_uploaded = self.config.upload.remove_uploaded
         self.chunk_size      = self.chunk_size_mb * 1024 * 1024
 
         self._pool        = None
         self._multipart   = None
         self._upload_done = False
-        if None in ( self.access_key, self.secret_key,self.s3_host):
+        if None in (self.access_key, self.secret_key,self.s3_host):
             raise "Invalid S3 security key or host detected!"
         try:
             self.s3_conn = S3Session(self.access_key, self.secret_key, self.s3_host)

--- a/mongodb_consistent_backup/Upload/S3/__init__.py
+++ b/mongodb_consistent_backup/Upload/S3/__init__.py
@@ -7,5 +7,4 @@ def config(parser):
     parser.add_argument("--upload.s3.bucket_prefix", dest="upload.s3.bucket_prefix", help="S3 Uploader destination bucket path prefix", type=str)
     parser.add_argument("--upload.s3.threads", dest="upload.s3.threads", help="S3 Uploader upload worker threads (default: 4)", default=4, type=int)
     parser.add_argument("--upload.s3.chunk_size_mb", dest="upload.s3.chunk_size_mb", help="S3 Uploader upload chunk size, in megabytes (default: 50)", default=50, type=int)
-    parser.add_argument("--upload.s3.remove_uploaded", dest="upload.s3.remove_uploaded",help="Remove source files after S3 Upload (default: false)", default=False, action="store_true")
     return parser

--- a/mongodb_consistent_backup/Upload/__init__.py
+++ b/mongodb_consistent_backup/Upload/__init__.py
@@ -3,4 +3,5 @@ from Upload import Upload
 
 def config(parser):
     parser.add_argument("--upload.method", dest="upload.method", help="Uploader method (default: none)", default='none', choices=['s3', 'none'])
+    parser.add_argument("--upload.remove_uploaded", dest="upload.remove_uploaded",help="Remove source files after successful upload (default: false)", default=False, action="store_true")
     return parser

--- a/mongodb_consistent_backup/__init__.py
+++ b/mongodb_consistent_backup/__init__.py
@@ -1,4 +1,5 @@
 import sys
+import traceback
 
 from Main import MongodbConsistentBackup
 
@@ -6,8 +7,10 @@ from Main import MongodbConsistentBackup
 # noinspection PyUnusedLocal
 def run():
     try:
-        MongodbConsistentBackup().run()
+        m = MongodbConsistentBackup()
+        m.run()
     except Exception, e:
         # noinspection PyUnusedLocal
-        print "Backup '%s' failed for mongodb instance %s:%s : %s" % (config.name, config.host, config.port, e)
+        print "Backup '%s' failed for mongodb instance %s:%s : %s" % (m.config.name, m.config.host, m.config.port, e)
+        traceback.print_exc()
         sys.exit(1)


### PR DESCRIPTION
1. Fixed pkgutil.walk_packages() to work in any directory, not just the git checkout.
2. Added traceback on uncaught errors to top-level __init__.py. It would print very little to explain issues before.
3. Created a simple timer: Common/Timer.py for timing exec times. Moved all timing code to it.
4. Made Oplog/Resolver/Resolver.py use methods for setting compression.
5. Made 'remove_uploaded' an Upload-wide flag (for all methods).
6. Improved logging messages.