### PR TITLE
MCB_1.0: Make a new log file per backup name

### DIFF
--- a/mongodb_consistent_backup/Logger.py
+++ b/mongodb_consistent_backup/Logger.py
@@ -7,6 +7,7 @@ from gzip import GzipFile
 class Logger:
     def __init__(self, config, backup_time):
         self.config      = config
+        self.backup_name = self.config.backup.name
         self.backup_time = backup_time
 
         self.log_level = logging.INFO
@@ -28,8 +29,8 @@ class Logger:
         try:
             logging.basicConfig(level=self.log_level, format=self.log_format)
             if self.do_file_log:
-                self.current_log_file = os.path.join(self.config.log_dir, "backup.log")
-                self.backup_log_file  = os.path.join(self.config.log_dir, "backup.%s.log" % self.backup_time)
+                self.current_log_file = os.path.join(self.config.log_dir, "backup.%s.log" % self.backup_name)
+                self.backup_log_file  = os.path.join(self.config.log_dir, "backup.%s.%s.log" % (self.backup_name, self.backup_time))
                 self.file_log = logging.FileHandler(self.backup_log_file)
                 self.file_log.setLevel(self.log_level)
                 self.file_log.setFormatter(logging.Formatter(self.log_format))

--- a/mongodb_consistent_backup/Oplog/Tailer/TailThread.py
+++ b/mongodb_consistent_backup/Oplog/Tailer/TailThread.py
@@ -15,7 +15,7 @@ from mongodb_consistent_backup.Oplog import Oplog
 
 
 class TailThread(Process):
-    def __init__(self, do_stop, uri, config, timer, oplog_file, state, dump_gzip=False, status_secs=30):
+    def __init__(self, do_stop, uri, config, timer, oplog_file, state, dump_gzip=False):
         Process.__init__(self)
         self.do_stop     = do_stop
         self.uri         = uri
@@ -24,7 +24,7 @@ class TailThread(Process):
         self.oplog_file  = oplog_file
         self.state       = state
         self.dump_gzip   = dump_gzip
-        self.status_secs = status_secs
+        self.status_secs = self.config.oplog.tailer.status_interval
         self.status_last = time()
 
         self.timer_name = "%s-%s" % (self.__class__.__name__, self.uri.replset)

--- a/mongodb_consistent_backup/Oplog/Tailer/Tailer.py
+++ b/mongodb_consistent_backup/Oplog/Tailer/Tailer.py
@@ -54,8 +54,7 @@ class Tailer(Task):
                 self.timer,
                 oplog_file,
                 oplog_state,
-                self.do_gzip(),
-                self.status_secs
+                self.do_gzip()
             )
             self.shards[shard] = {
                 'stop':   stop,


### PR DESCRIPTION
* Fix to stop different backups fighting over the same log file name: write a different log for backup name.
* Get status_secs in Oplog/Tailer/Tailer.py from config.