### PR TITLE
Return correct existing-backup count in log-line

### DIFF
--- a/mongodb_consistent_backup/State.py
+++ b/mongodb_consistent_backup/State.py
@@ -132,9 +132,9 @@ class StateRoot(StateBase):
         if os.path.isdir(self.base_dir):
             for subdir in os.listdir(self.base_dir):
                 try:
-                    if subdir == self.meta_name:
+                    bkp_path = os.path.join(self.base_dir, subdir)
+                    if subdir == self.meta_name or os.path.islink(bkp_path):
                         continue
-                    bkp_path   = os.path.join(self.base_dir, subdir)
                     state_path = os.path.join(bkp_path, self.meta_name)
                     state_file = os.path.join(state_path, "meta.bson")
                     done_path  = os.path.join(state_path, "done.bson")


### PR DESCRIPTION
Existing completed backups is always +1-more than is correct:

```
[2017-05-01 17:35:45,328] [INFO] [MainProcess] [State:load_backups:145] Found 2 existing completed backups for set
```
^^^ only 1 existing backup here