### PR TITLE
Fix for '[Errno 39] Directory not empty' when mongodump dump dir exists

### DIFF
--- a/mongodb_consistent_backup/Backup/Mongodump/MongodumpThread.py
+++ b/mongodb_consistent_backup/Backup/Mongodump/MongodumpThread.py
@@ -4,6 +4,7 @@ import sys
 
 from multiprocessing import Process
 from select import select
+from shutil import rmtree
 from signal import signal, SIGINT, SIGTERM, SIG_IGN
 from subprocess import Popen, PIPE
 
@@ -102,7 +103,7 @@ class MongodumpThread(Process):
         mongodump_cmd = self.mongodump_cmd()
         try:
             if os.path.isdir(self.dump_dir):
-                os.removedirs(self.dump_dir)
+                rmtree(self.dump_dir)
             os.makedirs(self.dump_dir)
             logging.debug("Running mongodump cmd: %s" % mongodump_cmd)
             self._process = Popen(mongodump_cmd, stderr=PIPE)


### PR DESCRIPTION
There is a os.removedirs() line to delete existing mongodump 'dump' dir if it exists (very rare). This blows up because the dir is never empty.

Example error:

```
[2017-05-01 17:33:47,569] [ERROR] [MongodumpThread-2] [MongodumpThread:run:114] Error performing mongodump: [Errno 39] Directory not empty: '/opt/mongodb/backup/test-replset/20170501_1733/test1/dump'
Traceback (most recent call last):
  File "/home/tim/.pex/install/mongodb_consistent_backup-1.0.0-py2-none-any.whl.a9dd591e217cc620357e2a76ae20f9610e0097d4/mongodb_consistent_backup-1.0.0-py2-none-any.whl/mongodb_consistent_backup/Backup/Mongodump/MongodumpThread.py", line 105, in run
    os.removedirs(self.dump_dir)
  File "/usr/lib64/python2.7/os.py", line 170, in removedirs
    rmdir(name)
OSError: [Errno 39] Directory not empty: '/opt/mongodb/backup/test-replset/20170501_1733/test1/dump'
```