### PR TITLE
prevent backup.mongodump.compression 'none' to be overwritten

### DIFF
--- a/mongodb_consistent_backup/Backup/Mongodump/Mongodump.py
+++ b/mongodb_consistent_backup/Backup/Mongodump/Mongodump.py
@@ -40,10 +40,7 @@ class Mongodump(Task):
         with hide('running', 'warnings'), settings(warn_only=True):
             self.version = local("%s --version|awk 'NR >1 {exit}; /version/{print $NF}'" % self.binary, capture=True)
 
-        if self.can_gzip():
-            if self.compression() == 'none':
-                self.compression('gzip')
-        elif self.compression() == 'gzip':
+        if not self.can_gzip() and self.compression() == 'gzip':
             logging.warning("mongodump gzip compression requested on binary that does not support gzip!")
 
     def can_gzip(self):

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -88,7 +88,7 @@ if [ -d ${srcdir} ]; then
 	source ${venvdir}/bin/activate
 
 	[ ! -d ${pipdir} ] && mkdir -p ${pipdir}
-	${venvdir}/bin/python2.7 ${venvdir}/bin/pip install --download-cache=${pipdir} pex requests
+	${venvdir}/bin/python2.7 ${venvdir}/bin/pip install --cache-dir=${pipdir} pex requests
 	if [ $? -gt 0 ]; then
 		echo "Failed to install pex utility for building!"
 		exit 1


### PR DESCRIPTION
* in case mongodump can_gzip(), the non-default value 'none' will be overwritten. Rolled it back to the former logic. Figure me out if it is done on purpose.
* pip of recent version doesn't recognize --download-cache.