### PR TITLE
ignore bson unicode decode error

### DIFF
--- a/mongodb_consistent_backup/Oplog/Oplog.py
+++ b/mongodb_consistent_backup/Oplog/Oplog.py
@@ -3,6 +3,7 @@ import logging
 
 from gzip import GzipFile
 from bson import BSON, decode_file_iter
+from bson.codec_options import CodecOptions
 
 from mongodb_consistent_backup.Errors import OperationError
 
@@ -44,7 +45,7 @@ class Oplog:
         try:
             oplog = self.open()
             logging.debug("Reading oplog file %s" % self.oplog_file)
-            for change in decode_file_iter(oplog):
+            for change in decode_file_iter(oplog, CodecOptions(unicode_decode_error_handler="ignore")):
                 if 'ts' in change:
                     self._last_ts = change['ts']
                 if self._first_ts is None and self._last_ts is not None:


### PR DESCRIPTION
I met such an error and the backup process hung.
````
[2017-05-11 04:18:47,505] [CRITICAL] [MongodumpThread-5] [Oplog:load:55] Error reading oplog file /var/lib/mongodb-consistent-backup/mytable/20170511_0256/ps-rs1/dump/oplog.bson! Error: 'utf8' codec can't decode byte 0xa1 in position 0: invalid start byte
[2017-05-11 04:18:47,505] [ERROR] [MongodumpThread-5] [MongodumpThread:run:121] Error loading oplog: 'utf8' codec can't decode byte 0xa1 in position 0: invalid start byte
Traceback (most recent call last):
  File "/var/lib/mongodb-consistent-backup/.pex/install/mongodb_consistent_backup-1.0.1-py2-none-any.whl.50d2483f9d3c33ae9bb528471e56ca495b2758f3/mongodb_consistent_backup-1.0.1-py2-none-any.whl/mongodb_consistent_backup/Backup/Mongodump/MongodumpThread.py", line 119, in run
    oplog.load()
  File "/var/lib/mongodb-consistent-backup/.pex/install/mongodb_consistent_backup-1.0.1-py2-none-any.whl.50d2483f9d3c33ae9bb528471e56ca495b2758f3/mongodb_consistent_backup-1.0.1-py2-none-any.whl/mongodb_consistent_backup/Oplog/Oplog.py", line 56, in load
    raise OperationError(e)
OperationError: 'utf8' codec can't decode byte 0xa1 in position 0: invalid start byte
````
I'm not sure if it is caused by invalid bson data, but it corrupted the backup anyway. Since the codes show only 'ts' is concerned, I suppose that ignoring the error is ok. How to you think?

I ran the patched version and it worked for me.

References:
https://jira.mongodb.org/browse/PYTHON-721