### PR TITLE
Ensure we use a mongos connection for 3.4 balancer commands

### DIFF
--- a/mongodb_consistent_backup/Common/DB.py
+++ b/mongodb_consistent_backup/Common/DB.py
@@ -45,7 +45,7 @@ class DB:
                 conn['admin'].command({"ping":1})
         except (ConnectionFailure, OperationFailure, ServerSelectionTimeoutError), e:
             logging.error("Unable to connect to %s! Error: %s" % (self.uri, e))
-            raise OperationError(e)
+            raise DBConnectionError(e)
         if conn is not None:
             self._conn = conn
         return self._conn


### PR DESCRIPTION
Even though the configsvr is now the balancer in 3.4, it doesn't have the balancer commands yet