### PR TITLE
Send CRITICAL state to NSCA on backup failure

### DIFF
--- a/mongodb_consistent_backup/Main.py
+++ b/mongodb_consistent_backup/Main.py
@@ -49,7 +49,7 @@ class MongodbConsistentBackup(object):
         self.logger                   = None
         self.current_log_file         = None
         self.backup_log_file          = None
-        self.last_error_msg           = None
+        self.last_error_msg           = ''
 
         try:
             self.setup_config()

--- a/mongodb_consistent_backup/Notify/Notify.py
+++ b/mongodb_consistent_backup/Notify/Notify.py
@@ -1,5 +1,6 @@
 import logging
 
+from mongodb_consistent_backup.Errors import Error, NotifyError
 from mongodb_consistent_backup.Notify.Nsca import Nsca
 from mongodb_consistent_backup.Pipeline import Stage
 
@@ -9,7 +10,6 @@ class Notify(Stage):
         super(Notify, self).__init__(self.__class__.__name__, manager, config, timer, base_dir, backup_dir)
         self.task = self.config.notify.method
 
-        self.completed = False
         self.notifications = []
         self.init()
 
@@ -19,19 +19,19 @@ class Notify(Stage):
 
     def run(self, *args):
         if self._task and len(self.notifications) > 0:
-            logging.info("Sending %i notification(s) to: %s" % (len(self.notifications), self._task.server))
-            self.timers.start(self.stage)
-            while len(self.notifications) > 0:
-                try:
-                    (success, message) = self.notifications.pop()
-                    state = self._task.failed
-                    if success:
-                        state = self._task.success
-                    self._task.run(state, message)
-                except:
-                    continue
-            self.timers.stop(self.stage)
-        self.completed = True
+            try:
+                logging.info("Sending %i notification(s) to: %s" % (len(self.notifications), self._task.server))
+                while len(self.notifications) > 0:
+                    try:
+                        (success, message) = self.notifications.pop()
+                        state = self._task.failed
+                        if success == True:
+                            state = self._task.success
+                        self._task.run(state, message)
+                    except NotifyError:
+                        continue
+            except Exception, e:
+                raise Error(e)
 
     def close(self):
         if self._task:

--- a/mongodb_consistent_backup/Notify/Nsca/Nsca.py
+++ b/mongodb_consistent_backup/Notify/Nsca/Nsca.py
@@ -54,7 +54,6 @@ class Nsca(Task):
 
     def run(self, ret_code, output):
         if self.notifier:
-            self.timer.start(self.timer_name)
             logging.info("Sending %sNSCA report to check host/name '%s/%s' at NSCA host %s" % (
                 self.mode_type,
                 self.check_host,
@@ -66,7 +65,6 @@ class Nsca(Task):
             try:
                 self.notifier.svc_result(self.check_host, self.check_name, ret_code, str(output))
                 logging.debug('Sent %sNSCA report to host %s' % (self.mode_type, self.server))
-                self.timer.stop(self.timer_name)
             except Exception, e:
                 logging.error('Failed to send %sNSCA report to host %s: %s' % (self.mode_type, self.server, sys.exc_info()[1]))
                 raise NotifyError(e)


### PR DESCRIPTION
If the tool hits the exception handler in Main.py we do not send a 'failed' state in the Notify NSCA method(!). Instead we are sending a success (Nagios state: OK).

1. Start 'Notifier' component at init-time instead of the starting of the backup so we can react to any failure properly. Moved to it's own method .setup_notifier() in Main.py.
2. Fixed incorrect fields passed into Notify on failure in Main.py .cleanup_on_failure().
3. Added more detail to failure message string.
4. Catch exceptions properly in Notify/Notify.py.
5. Remove 'timer' start/stop and 'completed' boolean in Notify/Notify.py - it's already handled by 'Stage'.