### PR TITLE
Handle mkdir in State.py properly

### DIFF
--- a/mongodb_consistent_backup/State.py
+++ b/mongodb_consistent_backup/State.py
@@ -6,6 +6,7 @@ from bson import BSON, decode_all
 from time import time
 
 from mongodb_consistent_backup.Common import Lock
+from mongodb_consistent_backup.Errors import OperationError
 
 
 class StateBase(object):
@@ -22,7 +23,14 @@ class StateBase(object):
         self.lock = Lock(self.state_lock, False)
 
         if not os.path.isdir(self.state_dir):
-            os.makedirs(self.state_dir)
+            # try recursive first, fallback to regular mkdir
+            try:
+                os.makedirs(self.state_dir)
+            except:
+                try:
+                    os.mkdir(self.state_dir)
+                except Exception, e:
+                    raise OperationError(e)
 
     def merge(self, new, old):
         merged = old.copy()

--- a/mongodb_consistent_backup/State.py
+++ b/mongodb_consistent_backup/State.py
@@ -23,12 +23,12 @@ class StateBase(object):
         self.lock = Lock(self.state_lock, False)
 
         if not os.path.isdir(self.state_dir):
-            # try recursive first, fallback to regular mkdir
+            # try normal mkdir first, fallback to recursive mkdir if there is an exception
             try:
-                os.makedirs(self.state_dir)
+                os.mkdir(self.state_dir)
             except:
                 try:
-                    os.mkdir(self.state_dir)
+                    os.makedirs(self.state_dir)
                 except Exception, e:
                     raise OperationError(e)
 


### PR DESCRIPTION
os.makedirs() is used in State.py to create the state dir, however this fails if you don't own the entire tree from / (root) up.

This PR tries a regular mkdir (os.mkdir) first and falls back to a recursive makedir (os.makedirs) if it fails. Also exceptions are caught properly now, this issue caused a large stacktrace.

Example of the original error:

```
...
[Errno 13] Permission denied: '/mnt/mongobackup/default'
Traceback (most recent call last):
  File "/var/lib/mongodb-consistent-backup/.pex/install/mongodb_consistent_backup-1.0.1-py2-none-any.whl.50d2483f9d3c33ae9bb528471e56ca495b2758f3/mongodb_consistent_backup-1.0.1-py2-none-any.whl/mongodb_consistent_backup/__init__.py", line 14, in run
    m = MongodbConsistentBackup()
  File "/var/lib/mongodb-consistent-backup/.pex/install/mongodb_consistent_backup-1.0.1-py2-none-any.whl.50d2483f9d3c33ae9bb528471e56ca495b2758f3/mongodb_consistent_backup-1.0.1-py2-none-any.whl/mongodb_consistent_backup/Main.py", line 62, in __init__
    self.setup_state()
  File "/var/lib/mongodb-consistent-backup/.pex/install/mongodb_consistent_backup-1.0.1-py2-none-any.whl.50d2483f9d3c33ae9bb528471e56ca495b2758f3/mongodb_consistent_backup-1.0.1-py2-none-any.whl/mongodb_consistent_backup/Main.py", line 96, in setup_state
    StateRoot(self.backup_root_directory, self.config).write(True)
  File "/var/lib/mongodb-consistent-backup/.pex/install/mongodb_consistent_backup-1.0.1-py2-none-any.whl.50d2483f9d3c33ae9bb528471e56ca495b2758f3/mongodb_consistent_backup-1.0.1-py2-none-any.whl/mongodb_consistent_backup/State.py", line 120, in __init__
    StateBase.__init__(self, base_dir, config)
  File "/var/lib/mongodb-consistent-backup/.pex/install/mongodb_consistent_backup-1.0.1-py2-none-any.whl.50d2483f9d3c33ae9bb528471e56ca495b2758f3/mongodb_consistent_backup-1.0.1-py2-none-any.whl/mongodb_consistent_backup/State.py", line 25, in __init__
    os.makedirs(self.state_dir)
  File "/usr/lib64/python2.7/os.py", line 150, in makedirs
    makedirs(head, mode)
  File "/usr/lib64/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 13] Permission denied: '/mnt/mongobackup/default'
```

This user owns /mnt/mongobackup but not /mnt, causing this error on os.makedirs(). The new logic would have avoided this.