### PR TITLE
Flake8 fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ install: bin/mongodb-consistent-backup
 	install -m 0644 LICENSE $(SHAREDIR)/$(NAME)/LICENSE
 	install -m 0644 README.rst $(SHAREDIR)/$(NAME)/README.rst
 
+flake8:
+	# Ignore long-lines and space-aligned = and : for now
+	flake8 --ignore E221,E241,E501 $(PWD)/$(NAME)
+
 uninstall:
 	rm -f $(BINDIR)/mongodb-consistent-backup
 	rm -rf $(SHAREDIR)/$(NAME)

--- a/README.rst
+++ b/README.rst
@@ -222,7 +222,7 @@ Submitting Code
 ~~~~~~~~~~~~~~~
 
 -  Submitted code must pass Python `'flake8' <https://pypi.python.org/pypi/flake8>`__ checks. Run *'make flake8'* to test.
--  To make review easier pull requests must address and solve a one problem at a time.
+-  To make review easier, pull requests must address and solve one problem at a time.
 
 Links
 ~~~~~

--- a/README.rst
+++ b/README.rst
@@ -218,6 +218,12 @@ Roadmap
 -  Documentation for running under Docker with persistent volumes
 -  Python unit tests
 
+Submitting Code
+~~~~~~~~~~~~~~~
+
+-  Submitted code must pass Python `'flake8' <https://pypi.python.org/pypi/flake8>`__ checks. Run *'make flake8'* to test.
+-  To make review easier pull requests must address and solve a one problem at a time.
+
 Links
 ~~~~~
 

--- a/mongodb_consistent_backup/Archive/Archive.py
+++ b/mongodb_consistent_backup/Archive/Archive.py
@@ -1,5 +1,3 @@
-from mongodb_consistent_backup.Archive.Tar import Tar
-from mongodb_consistent_backup.Archive.Zbackup import Zbackup
 from mongodb_consistent_backup.Pipeline import Stage
 
 

--- a/mongodb_consistent_backup/Archive/Tar/Tar.py
+++ b/mongodb_consistent_backup/Archive/Tar/Tar.py
@@ -7,7 +7,6 @@ from time import sleep
 from types import MethodType
 
 from TarThread import TarThread
-from mongodb_consistent_backup.Common import parse_method
 from mongodb_consistent_backup.Errors import Error, OperationError
 from mongodb_consistent_backup.Pipeline import Task
 
@@ -18,6 +17,7 @@ def _reduce_method(m):
         return getattr, (m.im_class, m.im_func.func_name)
     else:
         return getattr, (m.im_self, m.im_func.func_name)
+
 
 pickle(MethodType, _reduce_method)
 

--- a/mongodb_consistent_backup/Archive/Tar/TarThread.py
+++ b/mongodb_consistent_backup/Archive/Tar/TarThread.py
@@ -28,20 +28,20 @@ class TarThread(PoolThread):
         if os.path.isdir(self.backup_dir):
             if not os.path.isfile(self.output_file):
                 try:
-                     backup_base_dir  = os.path.dirname(self.backup_dir)
-                     backup_base_name = os.path.basename(self.backup_dir)
-        
-                     log_msg   = "Archiving directory: %s" % self.backup_dir
-                     cmd_flags = ["-C", backup_base_dir, "-cf", self.output_file, "--remove-files", backup_base_name]
-        
-                     if self.do_gzip():
-                         log_msg   = "Archiving and compressing directory: %s" % self.backup_dir
-                         cmd_flags = ["-C", backup_base_dir, "-czf", self.output_file, "--remove-files", backup_base_name]
-        
-                     logging.info(log_msg)
-                     self.running  = True
-                     self._command = LocalCommand(self.binary, cmd_flags, self.verbose)
-                     self.exit_code = self._command.run()
+                    backup_base_dir  = os.path.dirname(self.backup_dir)
+                    backup_base_name = os.path.basename(self.backup_dir)
+
+                    log_msg   = "Archiving directory: %s" % self.backup_dir
+                    cmd_flags = ["-C", backup_base_dir, "-cf", self.output_file, "--remove-files", backup_base_name]
+
+                    if self.do_gzip():
+                        log_msg   = "Archiving and compressing directory: %s" % self.backup_dir
+                        cmd_flags = ["-C", backup_base_dir, "-czf", self.output_file, "--remove-files", backup_base_name]
+
+                    logging.info(log_msg)
+                    self.running  = True
+                    self._command = LocalCommand(self.binary, cmd_flags, self.verbose)
+                    self.exit_code = self._command.run()
                 except Exception, e:
                     logging.fatal("Failed archiving file: %s! Error: %s" % (self.output_file, e))
                 finally:

--- a/mongodb_consistent_backup/Archive/Tar/__init__.py
+++ b/mongodb_consistent_backup/Archive/Tar/__init__.py
@@ -1,9 +1,9 @@
-from Tar import Tar
+from Tar import Tar  # NOQA
 
 
 def config(parser):
     parser.add_argument("--archive.tar.compression", dest="archive.tar.compression",
                         help="Tar archiver compression method (default: gzip)", default='gzip', choices=['gzip', 'none'])
-    parser.add_argument("--archive.tar.threads", dest="archive.tar.threads", 
+    parser.add_argument("--archive.tar.threads", dest="archive.tar.threads",
                         help="Number of Tar archiver threads to use (default: 1-per-CPU)", default=0, type=int)
     return parser

--- a/mongodb_consistent_backup/Archive/Zbackup/Zbackup.py
+++ b/mongodb_consistent_backup/Archive/Zbackup/Zbackup.py
@@ -95,20 +95,20 @@ class Zbackup(Task):
                 return None
             except Exception, e:
                 raise OperationError("Could not gather ZBackup version: %s" % e)
-    
+
     def has_zbackup(self):
         if self.version():
-           return True
+            return True
         return False
 
     def close(self, exit_code=None, frame=None):
         del exit_code
         del frame
         if not self.stopped:
-            if self._zbackup and self._zbackup.poll() == None:
+            if self._zbackup and self._zbackup.poll() is None:
                 logging.debug("Stopping running ZBackup command")
                 self._zbackup.terminate()
-            if self._tar and self._tar.poll() == None:
+            if self._tar and self._tar.poll() is None:
                 logging.debug("Stopping running ZBackup tar command")
                 self._tar.terminate()
             self.stopped = True
@@ -131,12 +131,12 @@ class Zbackup(Task):
                 self.poll()
                 if tar_done:
                     self._zbackup.communicate()
-                    if self._zbackup.poll() != None:
+                    if self._zbackup.poll() is not None:
                         logging.info("ZBackup completed successfully with exit code: %i" % self._zbackup.returncode)
                         if self._zbackup.returncode != 0:
                             raise OperationError("ZBackup exited with code: %i!" % self._zbackup.returncode)
                         break
-                elif self._tar.poll() != None:
+                elif self._tar.poll() is not None:
                     if self._tar.returncode == 0:
                         logging.debug("ZBackup tar command completed successfully with exit code: %i" % self._tar.returncode)
                         tar_done = True
@@ -160,9 +160,9 @@ class Zbackup(Task):
             lock = Lock(self.zbackup_lock)
             lock.acquire()
             try:
-                logging.info("Starting ZBackup version: %s (options: compression=%s, encryption=%s, threads=%i, cache_mb=%i)" %
-                    (self.version(), self.compression(), self.encrypted, self.threads(), self.zbackup_cache_mb)
-                )
+                logging.info("Starting ZBackup version: %s (options: compression=%s, encryption=%s, threads=%i, cache_mb=%i)" % (
+                    self.version(), self.compression(), self.encrypted, self.threads(), self.zbackup_cache_mb
+                ))
                 self.running = True
                 try:
                     for sub_dir in os.listdir(self.backup_dir):

--- a/mongodb_consistent_backup/Archive/Zbackup/__init__.py
+++ b/mongodb_consistent_backup/Archive/Zbackup/__init__.py
@@ -1,4 +1,4 @@
-from Zbackup import Zbackup
+from Zbackup import Zbackup  # NOQA
 
 
 def config(parser):

--- a/mongodb_consistent_backup/Archive/__init__.py
+++ b/mongodb_consistent_backup/Archive/__init__.py
@@ -1,6 +1,6 @@
-from Archive import Archive
+from Archive import Archive  # NOQA
 
 
 def config(parser):
-    parser.add_argument("--archive.method", dest="archive.method", help="Archiver method (default: tar)", default='tar', choices=['tar','zbackup','none'])
+    parser.add_argument("--archive.method", dest="archive.method", help="Archiver method (default: tar)", default='tar', choices=['tar', 'zbackup', 'none'])
     return parser

--- a/mongodb_consistent_backup/Backup/Backup.py
+++ b/mongodb_consistent_backup/Backup/Backup.py
@@ -1,4 +1,4 @@
-from mongodb_consistent_backup.Backup.Mongodump import Mongodump
+from mongodb_consistent_backup.Backup.Mongodump import Mongodump  # NOQA
 from mongodb_consistent_backup.Pipeline import Stage
 
 

--- a/mongodb_consistent_backup/Backup/Mongodump/Mongodump.py
+++ b/mongodb_consistent_backup/Backup/Mongodump/Mongodump.py
@@ -1,14 +1,13 @@
-import os, sys
+import os
 import logging
-import signal
+import sys
 
 from math import floor
-from multiprocessing import cpu_count
 from subprocess import check_output
 from time import sleep
 
 from mongodb_consistent_backup.Common import MongoUri, config_to_string
-from mongodb_consistent_backup.Errors import Error, OperationError
+from mongodb_consistent_backup.Errors import OperationError
 from mongodb_consistent_backup.Oplog import OplogState
 from mongodb_consistent_backup.Pipeline import Task
 
@@ -82,8 +81,6 @@ class Mongodump(Task):
     def get_summaries(self):
         for shard in self.states:
             state = self.states[shard]
-            host  = state.get('host')
-            port  = state.get('port')
             self._summary[shard] = state.get().copy()
 
     def wait(self):

--- a/mongodb_consistent_backup/Backup/Mongodump/MongodumpThread.py
+++ b/mongodb_consistent_backup/Backup/Mongodump/MongodumpThread.py
@@ -61,7 +61,7 @@ class MongodumpThread(Process):
                 (date, line) = line.split("\t")
             elif is_datetime(line):
                 return None
-            return "%s:\t%s" % (self.uri, line) 
+            return "%s:\t%s" % (self.uri, line)
         except:
             return None
 
@@ -105,7 +105,7 @@ class MongodumpThread(Process):
                             break
                         else:
                             logging.info(line)
-                if self._process.poll() != None:
+                if self._process.poll() is not None:
                     break
         except Exception, e:
             logging.exception("Error reading mongodump output: %s" % e)
@@ -117,7 +117,7 @@ class MongodumpThread(Process):
         mongodump_cmd   = [self.binary]
         mongodump_flags = ["--host", mongodump_uri.host, "--port", str(mongodump_uri.port), "--oplog", "--out", "%s/dump" % self.backup_dir]
         if self.threads > 0:
-            mongodump_flags.extend(["--numParallelCollections="+str(self.threads)])
+            mongodump_flags.extend(["--numParallelCollections=" + str(self.threads)])
         if self.dump_gzip:
             mongodump_flags.extend(["--gzip"])
         if tuple("3.4.0".split(".")) <= tuple(self.version.split(".")):
@@ -131,7 +131,7 @@ class MongodumpThread(Process):
                 mongodump_flags.extend(["-u", self.user, "-p", '""'])
                 self.do_stdin_passwd = True
             else:
-                logging.warning("Mongodump is too old to set password securely! Upgrade to mongodump >= 3.0.2 to resolve this") 
+                logging.warning("Mongodump is too old to set password securely! Upgrade to mongodump >= 3.0.2 to resolve this")
                 mongodump_flags.extend(["-u", self.user, "-p", self.password])
         mongodump_cmd.extend(mongodump_flags)
         return mongodump_cmd

--- a/mongodb_consistent_backup/Backup/Mongodump/__init__.py
+++ b/mongodb_consistent_backup/Backup/Mongodump/__init__.py
@@ -1,4 +1,4 @@
-from Mongodump import Mongodump
+from Mongodump import Mongodump  # NOQA
 
 
 def config(parser):

--- a/mongodb_consistent_backup/Backup/__init__.py
+++ b/mongodb_consistent_backup/Backup/__init__.py
@@ -1,4 +1,4 @@
-from Backup import Backup
+from Backup import Backup  # NOQA
 
 
 def config(parser):

--- a/mongodb_consistent_backup/Common/Config.py
+++ b/mongodb_consistent_backup/Common/Config.py
@@ -32,7 +32,7 @@ class PrintVersions(Action):
 
 class ConfigParser(BaseConfiguration):
     def makeParserLoadSubmodules(self, parser):
-        for _, modname, ispkg in walk_packages(path=mongodb_consistent_backup.__path__, prefix=mongodb_consistent_backup.__name__+'.'):
+        for _, modname, ispkg in walk_packages(path=mongodb_consistent_backup.__path__, prefix=mongodb_consistent_backup.__name__ + '.'):
             if not ispkg:
                 continue
             try:
@@ -41,7 +41,7 @@ class ConfigParser(BaseConfiguration):
                 for comp in components[1:]:
                     mod = getattr(mod, comp)
                 parser = mod.config(parser)
-            except AttributeError, e:
+            except AttributeError:
                 continue
         return parser
 
@@ -104,7 +104,7 @@ class Config(object):
                         value = "******"
                     ret[key] = value
             return ret
-        elif isinstance(data, (str, int, bool)): # or isinstance(data, int) or isinstance(data, bool):
+        elif isinstance(data, (str, int, bool)):
             return data
 
     def dump(self):

--- a/mongodb_consistent_backup/Common/DB.py
+++ b/mongodb_consistent_backup/Common/DB.py
@@ -6,7 +6,7 @@ from pymongo import DESCENDING, CursorType, MongoClient
 from pymongo.errors import ConnectionFailure, OperationFailure, ServerSelectionTimeoutError
 from time import sleep
 
-from mongodb_consistent_backup.Errors import DBAuthenticationError, DBConnectionError, DBOperationError, Error, OperationError
+from mongodb_consistent_backup.Errors import DBAuthenticationError, DBConnectionError, DBOperationError, Error
 
 
 class DB:
@@ -31,8 +31,9 @@ class DB:
         try:
             if self.do_replset:
                 self.replset = self.uri.replset
-            logging.debug("Getting MongoDB connection to %s (replicaSet=%s, readPreference=%s)" % 
-                         (self.uri, self.replset, self.read_pref))
+            logging.debug("Getting MongoDB connection to %s (replicaSet=%s, readPreference=%s)" % (
+                self.uri, self.replset, self.read_pref
+            ))
             conn = MongoClient(
                 connect=self.do_connect,
                 host=self.uri.hosts(),
@@ -44,7 +45,7 @@ class DB:
                 w="majority"
             )
             if self.do_connect:
-                conn['admin'].command({"ping":1})
+                conn['admin'].command({"ping": 1})
         except (ConnectionFailure, OperationFailure, ServerSelectionTimeoutError), e:
             logging.error("Unable to connect to %s! Error: %s" % (self.uri, e))
             raise DBConnectionError(e)
@@ -134,7 +135,7 @@ class DB:
         comment = "%s:%s;%s:%i" % (caller.__name__, frame.function, frame.filename, frame.lineno)
         if not ts:
             ts = self.get_oplog_tail_ts()
-        query = {'ts':{'$gte':ts}}
+        query = {'ts': {'$gte': ts}}
         logging.debug("Querying oplog on %s with query: %s" % (self.uri, query))
         # http://api.mongodb.com/python/current/examples/tailable.html
         return self.get_oplog_rs().find(query, cursor_type=CursorType.TAILABLE_AWAIT, oplog_replay=True).comment(comment)

--- a/mongodb_consistent_backup/Common/LocalCommand.py
+++ b/mongodb_consistent_backup/Common/LocalCommand.py
@@ -42,7 +42,7 @@ class LocalCommand:
                 sleep(0.1)
         except Exception, e:
             raise Error(e)
-    
+
         if self._process.returncode != 0:
             raise OperationError("%s command failed with exit code %i! Stderr output:\n%s" % (
                 self.command,

--- a/mongodb_consistent_backup/Common/Lock.py
+++ b/mongodb_consistent_backup/Common/Lock.py
@@ -8,11 +8,11 @@ from mongodb_consistent_backup.Errors import OperationError
 class Lock:
     def __init__(self, lock_file, acquire=True):
         self.lock_file = lock_file
-    
+
         self._lock = None
         if acquire:
             self.acquire()
-    
+
     def acquire(self):
         try:
             self._lock = open(self.lock_file, "w")
@@ -24,7 +24,7 @@ class Lock:
             if self._lock:
                 self._lock.close()
             raise OperationError("Could not acquire lock on file: %s!" % self.lock_file)
-    
+
     def release(self):
         if self._lock:
             logging.debug("Releasing exclusive lock on file: %s" % self.lock_file)

--- a/mongodb_consistent_backup/Common/MongoUri.py
+++ b/mongodb_consistent_backup/Common/MongoUri.py
@@ -15,6 +15,7 @@ class MongoAddr:
     def __str__(self):
         return self.str()
 
+
 class MongoUri:
     def __init__(self, url, default_port=27017, replset=None):
         self.url          = url
@@ -49,8 +50,8 @@ class MongoUri:
             addr = MongoAddr()
             addr.replset = self.replset
             if ":" in url:
-                 addr.host, addr.port = url.split(":")
-                 addr.port = int(addr.port)
+                addr.host, addr.port = url.split(":")
+                addr.port = int(addr.port)
             else:
                 addr.host = url
                 if not addr.port:

--- a/mongodb_consistent_backup/Common/Timer.py
+++ b/mongodb_consistent_backup/Common/Timer.py
@@ -8,7 +8,7 @@ class Timer:
         self.timers = manager.dict()
 
     def start(self, timer_name):
-        self.timers[timer_name] = { 'start': time(), 'started': True }
+        self.timers[timer_name] = {'start': time(), 'started': True}
 
     def stop(self, timer_name):
         try:
@@ -22,7 +22,7 @@ class Timer:
             else:
                 raise OperationError("No started timer named %s to stop!" % timer_name)
         except IOError:
-            pass            
+            pass
 
     def duration(self, timer_name):
         try:

--- a/mongodb_consistent_backup/Common/Util.py
+++ b/mongodb_consistent_backup/Common/Util.py
@@ -11,6 +11,7 @@ def config_to_string(config):
         config_pairs.append("%s=%s" % (key, config[key]))
     return ", ".join(config_pairs)
 
+
 def is_datetime(string):
     try:
         parser.parse(string)
@@ -18,8 +19,10 @@ def is_datetime(string):
     except:
         return False
 
+
 def parse_method(method):
     return method.rstrip().lower()
+
 
 def validate_hostname(hostname):
     try:

--- a/mongodb_consistent_backup/Common/__init__.py
+++ b/mongodb_consistent_backup/Common/__init__.py
@@ -1,7 +1,7 @@
-from Config import Config
-from DB import DB
-from LocalCommand import LocalCommand
-from Lock import Lock
-from MongoUri import MongoUri
-from Timer import Timer
-from Util import config_to_string, is_datetime, parse_method, validate_hostname 
+from Config import Config  # NOQA
+from DB import DB  # NOQA
+from LocalCommand import LocalCommand  # NOQA
+from Lock import Lock  # NOQA
+from MongoUri import MongoUri  # NOQA
+from Timer import Timer  # NOQA
+from Util import config_to_string, is_datetime, parse_method, validate_hostname  # NOQA

--- a/mongodb_consistent_backup/Errors.py
+++ b/mongodb_consistent_backup/Errors.py
@@ -2,21 +2,26 @@ class Error(Exception):
     """Raised when something failed in an unexpected and unrecoverable way"""
     pass
 
+
 class OperationError(Error):
     """Raised when an operation failed in an expected but unrecoverable way"""
     pass
+
 
 class NotifyError(Error):
     """Raised when an notify operation failed in an expected but unrecoverable way"""
     pass
 
+
 class DBConnectionError(OperationError):
     """Raised when a db connection error occurs"""
     pass
 
+
 class DBAuthenticationError(OperationError):
     """Raised when a db authentication error occurs"""
     pass
+
 
 class DBOperationError(OperationError):
     """Raised when a db operation error occurs"""

--- a/mongodb_consistent_backup/Logger.py
+++ b/mongodb_consistent_backup/Logger.py
@@ -41,7 +41,7 @@ class Logger:
                 self.file_log.setLevel(self.log_level)
                 self.file_log.setFormatter(logging.Formatter(self.log_format))
                 logging.getLogger('').addHandler(self.file_log)
-            except OSError, e:
+            except OSError:
                 logging.warning("Could not start file log handler, writing to stdout only")
                 pass
 

--- a/mongodb_consistent_backup/Main.py
+++ b/mongodb_consistent_backup/Main.py
@@ -9,7 +9,7 @@ from multiprocessing import current_process, Event, Manager
 from Archive import Archive
 from Backup import Backup
 from Common import Config, DB, Lock, MongoUri, Timer
-from Errors import Error, NotifyError, OperationError
+from Errors import NotifyError, OperationError
 from Logger import Logger
 from Notify import Notify
 from Oplog import Tailer, Resolver
@@ -360,7 +360,7 @@ class MongodbConsistentBackup(object):
                     self.timer,
                     self.backup_root_subdirectory,
                     self.backup_directory,
-                    self.replsets, 
+                    self.replsets,
                     self.backup_stop,
                     self.sharding
                 )

--- a/mongodb_consistent_backup/Notify/Notify.py
+++ b/mongodb_consistent_backup/Notify/Notify.py
@@ -1,7 +1,7 @@
 import logging
 
 from mongodb_consistent_backup.Errors import Error, NotifyError
-from mongodb_consistent_backup.Notify.Nsca import Nsca
+from mongodb_consistent_backup.Notify.Nsca import Nsca  # NOQA
 from mongodb_consistent_backup.Pipeline import Stage
 
 
@@ -25,7 +25,7 @@ class Notify(Stage):
                     try:
                         (success, message) = self.notifications.pop()
                         state = self._task.failed
-                        if success == True:
+                        if success is True:
                             state = self._task.success
                         self._task.run(state, message)
                     except NotifyError:

--- a/mongodb_consistent_backup/Notify/Nsca/Nsca.py
+++ b/mongodb_consistent_backup/Notify/Nsca/Nsca.py
@@ -3,7 +3,7 @@ import sys
 
 from pynsca import NSCANotifier
 
-from mongodb_consistent_backup.Errors import Error, NotifyError, OperationError
+from mongodb_consistent_backup.Errors import NotifyError, OperationError
 from mongodb_consistent_backup.Pipeline import Task
 
 

--- a/mongodb_consistent_backup/Notify/Nsca/__init__.py
+++ b/mongodb_consistent_backup/Notify/Nsca/__init__.py
@@ -1,4 +1,4 @@
-from Nsca import Nsca
+from Nsca import Nsca  # NOQA
 
 
 def config(parser):

--- a/mongodb_consistent_backup/Notify/__init__.py
+++ b/mongodb_consistent_backup/Notify/__init__.py
@@ -1,6 +1,6 @@
-from Notify import Notify
+from Notify import Notify  # NOQA
 
 
 def config(parser):
-    parser.add_argument("--notify.method", dest="notify.method", help="Notifier method (default: none)", default='none', choices=['nsca','none'])
+    parser.add_argument("--notify.method", dest="notify.method", help="Notifier method (default: none)", default='none', choices=['nsca', 'none'])
     return parser

--- a/mongodb_consistent_backup/Oplog/Oplog.py
+++ b/mongodb_consistent_backup/Oplog/Oplog.py
@@ -118,9 +118,9 @@ class Oplog:
         return self._last_ts
 
     def stat(self):
-       return {
-           'file':     self.oplog_file,
-           'count':    self.count(),
-           'first_ts': self.first_ts(),
-           'last_ts':  self.last_ts()
-       }
+        return {
+            'file':     self.oplog_file,
+            'count':    self.count(),
+            'first_ts': self.first_ts(),
+            'last_ts':  self.last_ts()
+        }

--- a/mongodb_consistent_backup/Oplog/OplogState.py
+++ b/mongodb_consistent_backup/Oplog/OplogState.py
@@ -9,7 +9,7 @@ class OplogState:
         self.uri = uri
         self.oplog_file = oplog_file
 
-        try: 
+        try:
             self._state = manager.dict()
             if uri:
                 self._state['uri'] = self.uri.str()
@@ -33,9 +33,9 @@ class OplogState:
                     return state[key]
                 else:
                     return None
-            return state 
-        except IOError, e:
-            return None 
+            return state
+        except IOError:
+            return None
         except Exception, e:
             raise OperationError(e)
 
@@ -58,7 +58,7 @@ class OplogState:
             f.write(json.dumps(self._state))
         except Exception, e:
             logging.debug("Writing oplog state to file: '%s'! Error: %s" % (self.oplog_file, e))
-            raise OperationError(e) 
+            raise OperationError(e)
         finally:
             if f:
                 f.close()

--- a/mongodb_consistent_backup/Oplog/Resolver/__init__.py
+++ b/mongodb_consistent_backup/Oplog/Resolver/__init__.py
@@ -1,2 +1,1 @@
-from Resolver import Resolver
-
+from Resolver import Resolver  # NOQA

--- a/mongodb_consistent_backup/Oplog/Tailer/TailThread.py
+++ b/mongodb_consistent_backup/Oplog/Tailer/TailThread.py
@@ -95,7 +95,7 @@ class TailThread(Process):
         try:
             logging.info("Tailing oplog on %s for changes" % self.uri)
             self.timer.start(self.timer_name)
-    
+
             self.state.set('running', True)
             self.connect()
             oplog = self.oplog()
@@ -109,11 +109,11 @@ class TailThread(Process):
                             if self.last_ts and self.last_ts >= doc['ts']:
                                 continue
                             oplog.add(doc)
-    
+
                             # update states
                             self.count  += 1
                             self.last_ts = doc['ts']
-                            if self.first_ts == None:
+                            if self.first_ts is None:
                                 self.first_ts = self.last_ts
                             update = {
                                 'count':    self.count,
@@ -121,7 +121,7 @@ class TailThread(Process):
                                 'last_ts':  self.last_ts
                             }
                             self.state.set(None, update, True)
-    
+
                             # print status report every N seconds
                             self.status()
                         except NotMasterError:
@@ -154,7 +154,7 @@ class TailThread(Process):
             logging.error("Tailer %s encountered an unexpected error: %s" % (self.uri, e))
             self.exit_code = 1
             self.backup_stop.set()
-            raise e 
+            raise e
         finally:
             if self._cursor:
                 logging.debug("Stopping oplog cursor on %s" % self.uri)
@@ -171,5 +171,5 @@ class TailThread(Process):
                 log_msg_extra = "%s, end ts: %s" % (log_msg_extra, self.last_ts)
             logging.info("Done tailing oplog on %s, %s" % (self.uri, log_msg_extra))
             self.state.set('completed', True)
- 
+
         sys.exit(self.exit_code)

--- a/mongodb_consistent_backup/Oplog/Tailer/Tailer.py
+++ b/mongodb_consistent_backup/Oplog/Tailer/Tailer.py
@@ -1,13 +1,12 @@
-import bson
 import os
 import logging
 
 from bson.timestamp import Timestamp
-from multiprocessing import Event, Manager
+from multiprocessing import Event
 from time import time, sleep
 
 from TailThread import TailThread
-from mongodb_consistent_backup.Common import parse_method, DB, MongoUri
+from mongodb_consistent_backup.Common import MongoUri
 from mongodb_consistent_backup.Errors import OperationError
 from mongodb_consistent_backup.Oplog import OplogState
 from mongodb_consistent_backup.Pipeline import Task
@@ -88,7 +87,6 @@ class Tailer(Task):
         for shard in self.shards:
             replset = self.replsets[shard]
             state   = self.shards[shard]['state']
-            stop    = self.shards[shard]['stop']
             thread  = self.shards[shard]['thread']
 
             try:
@@ -103,7 +101,7 @@ class Tailer(Task):
                 except:
                     logging.warning("Could not get current optime from PRIMARY! Using now as a stop time")
                     timestamp = Timestamp(int(time()), 0)
-    
+
                 # wait for replication to get in sync
                 while state.get('last_ts') and state.get('last_ts') < timestamp:
                     logging.info('Waiting for %s tailer to reach ts: %s, currrent: %s' % (uri, timestamp, state.get('last_ts')))

--- a/mongodb_consistent_backup/Oplog/Tailer/__init__.py
+++ b/mongodb_consistent_backup/Oplog/Tailer/__init__.py
@@ -1,2 +1,1 @@
-from Tailer import Tailer
-
+from Tailer import Tailer  # NOQA

--- a/mongodb_consistent_backup/Oplog/__init__.py
+++ b/mongodb_consistent_backup/Oplog/__init__.py
@@ -1,11 +1,11 @@
-from Oplog import Oplog
-from OplogState import OplogState
-from Resolver import Resolver
-from Tailer import Tailer
+from Oplog import Oplog  # NOQA
+from OplogState import OplogState  # NOQA
+from Resolver import Resolver  # NOQA
+from Tailer import Tailer  # NOQA
 
 
 def config(parser):
-    parser.add_argument("--oplog.compression", dest="oplog.compression", help="Compression method to use on captured oplog file (default: none)", choices=["none","gzip"], default="none")
+    parser.add_argument("--oplog.compression", dest="oplog.compression", help="Compression method to use on captured oplog file (default: none)", choices=["none", "gzip"], default="none")
     parser.add_argument("--oplog.flush.max_docs", dest="oplog.flush.max_docs", help="Maximum number of oplog document writes to trigger a flush of the backup oplog file (default: 1000)", default=1000, type=int)
     parser.add_argument("--oplog.flush.max_secs", dest="oplog.flush.max_secs", help="Number of seconds to wait to flush the backup oplog file, if 'max_docs' is not reached (default: 1)", default=1, type=int)
     parser.add_argument("--oplog.resolver.threads", dest="oplog.resolver.threads", help="Number of threads to use during resolver step (default: 1-per-CPU)", default=0, type=int)

--- a/mongodb_consistent_backup/Pipeline/PoolThread.py
+++ b/mongodb_consistent_backup/Pipeline/PoolThread.py
@@ -1,5 +1,3 @@
-import logging
-
 from mongodb_consistent_backup.Errors import Error
 
 

--- a/mongodb_consistent_backup/Pipeline/Stage.py
+++ b/mongodb_consistent_backup/Pipeline/Stage.py
@@ -1,7 +1,6 @@
 import logging
 import sys
 
-from mongodb_consistent_backup.Common import config_to_string, parse_method
 from mongodb_consistent_backup.Errors import Error, OperationError
 
 from Task import Task

--- a/mongodb_consistent_backup/Pipeline/__init__.py
+++ b/mongodb_consistent_backup/Pipeline/__init__.py
@@ -1,3 +1,3 @@
-from PoolThread import PoolThread
-from Stage import Stage
-from Task import Task
+from PoolThread import PoolThread  # NOQA
+from Stage import Stage  # NOQA
+from Task import Task  # NOQA

--- a/mongodb_consistent_backup/Replication/ReplsetSharded.py
+++ b/mongodb_consistent_backup/Replication/ReplsetSharded.py
@@ -1,7 +1,5 @@
-import logging
-
 from mongodb_consistent_backup.Common import DB, MongoUri
-from mongodb_consistent_backup.Errors import DBConnectionError, Error
+from mongodb_consistent_backup.Errors import Error
 from mongodb_consistent_backup.Sharding import Sharding
 from Replset import Replset
 
@@ -13,7 +11,7 @@ class ReplsetSharded:
         self.db           = db
         self.max_lag_secs = self.config.replication.max_lag_secs
 
-        self.replsets      = {} 
+        self.replsets      = {}
         self.replset_conns = {}
 
         # Check Sharding class:
@@ -35,14 +33,14 @@ class ReplsetSharded:
         return summary
 
     def get_replset_connection(self, uri, force=False):
-        if force or not uri.replset in self.replset_conns:
+        if force or uri.replset not in self.replset_conns:
             self.replset_conns[uri.replset] = DB(uri, self.config, True)
         return self.replset_conns[uri.replset]
 
     def get_replsets(self, force=False):
         for shard in self.sharding.shards():
             shard_uri = MongoUri(shard['host'])
-            if force or not shard_uri.replset in self.replsets:
+            if force or shard_uri.replset not in self.replsets:
                 rs_db = self.get_replset_connection(shard_uri)
                 self.replsets[shard_uri.replset] = Replset(self.config, rs_db)
 

--- a/mongodb_consistent_backup/Replication/__init__.py
+++ b/mongodb_consistent_backup/Replication/__init__.py
@@ -1,5 +1,5 @@
-from Replset import Replset
-from ReplsetSharded import ReplsetSharded
+from Replset import Replset  # NOQA
+from ReplsetSharded import ReplsetSharded  # NOQA
 
 
 def config(parser):
@@ -8,5 +8,5 @@ def config(parser):
     parser.add_argument("--replication.max_priority", dest="replication.max_priority", help="Max priority of secondary members for backup (default: 1000)", default=1000, type=int)
     parser.add_argument("--replication.hidden_only", dest="replication.hidden_only", help="Only use hidden secondary members for backup (default: false)", default=False, action="store_true")
     # todo: add tag-specific backup option
-    #parser.add_argument("-replication.use_tag", dest="replication.use_tag", help="Only use secondary members with tag for backup", type=str)
+    # parser.add_argument("-replication.use_tag", dest="replication.use_tag", help="Only use secondary members with tag for backup", type=str)
     return parser

--- a/mongodb_consistent_backup/State.py
+++ b/mongodb_consistent_backup/State.py
@@ -35,19 +35,19 @@ class StateBase(object):
     def merge(self, new, old):
         merged = old.copy()
         merged.update(new)
-        return merged 
+        return merged
 
     def load(self, load_one=False):
-         f = None
-         try:
+        f = None
+        try:
             f = open(self.state_file, "r")
             data = decode_all(f.read())
             if load_one and len(data) > 0:
                 return data[0]
             return data
-         except Exception, e:
+        except Exception, e:
             raise e
-         finally:
+        finally:
             if f:
                 f.close()
 
@@ -57,7 +57,7 @@ class StateBase(object):
             self.lock.acquire()
             if do_merge and os.path.isfile(self.state_file):
                 curr = self.load(True)
-                data = self.merge(self.state, curr)
+                self.merge(self.state, curr)
             f = open(self.state_file, 'w+')
             logging.debug("Writing %s state file: %s" % (self.__class__.__name__, self.state_file))
             self.state['updated_at'] = int(time())
@@ -67,7 +67,7 @@ class StateBase(object):
                 f.close()
             self.lock.release()
 
-    
+
 class StateBaseReplset(StateBase):
     def __init__(self, base_dir, config, backup_time, set_name, filename):
         StateBase.__init__(self, base_dir, config, filename)
@@ -120,7 +120,7 @@ class StateBackup(StateBase):
 
     def set(self, name, summary):
         self.state[name] = summary
-        self.write(True)        
+        self.write(True)
 
 
 class StateRoot(StateBase):
@@ -152,9 +152,9 @@ class StateRoot(StateBase):
                     continue
             logging.info("Found %i existing completed backups for set" % len(backups))
         return backups
-            
+
+
 class StateDoneStamp(StateBase):
     def __init__(self, base_dir, config):
         StateBase.__init__(self, base_dir, config, "done.bson")
         self.state = {'done': True}
-

--- a/mongodb_consistent_backup/Upload/Gs/Gs.py
+++ b/mongodb_consistent_backup/Upload/Gs/Gs.py
@@ -8,7 +8,7 @@ from types import MethodType
 
 from mongodb_consistent_backup.Errors import OperationError
 from mongodb_consistent_backup.Pipeline import Task
-from mongodb_consistent_backup.Upload.Gs.GsUploadThread import GsUploadThread
+from GsUploadThread import GsUploadThread
 
 
 # Allows pooled .apply_async()s to work on Class-methods:
@@ -17,6 +17,8 @@ def _reduce_method(m):
         return getattr, (m.im_class, m.im_func.func_name)
     else:
         return getattr, (m.im_self, m.im_func.func_name)
+
+
 pickle(MethodType, _reduce_method)
 
 

--- a/mongodb_consistent_backup/Upload/Gs/__init__.py
+++ b/mongodb_consistent_backup/Upload/Gs/__init__.py
@@ -1,5 +1,4 @@
-from Gs import Gs
-from GsUploadThread import GsUploadThread
+from Gs import Gs  # NOQA
 
 
 def config(parser):

--- a/mongodb_consistent_backup/Upload/S3/S3.py
+++ b/mongodb_consistent_backup/Upload/S3/S3.py
@@ -20,6 +20,8 @@ def _reduce_method(m):
         return getattr, (m.im_class, m.im_func.func_name)
     else:
         return getattr, (m.im_self, m.im_func.func_name)
+
+
 pickle(MethodType, _reduce_method)
 
 
@@ -38,10 +40,7 @@ class S3(Task):
         self.secure          = self.config.upload.s3.secure
         self.retries         = self.config.upload.s3.retries
         self.s3_acl          = self.config.upload.s3.acl
-
-        self.key_prefix = base_dir
-        if 'key_prefix' in self.args:
-            self.key_prefix = key_prefix
+        self.key_prefix      = base_dir
 
         self._pool        = None
         self._multipart   = None
@@ -105,7 +104,7 @@ class S3(Task):
 
                 part_count = 0
                 for part in boto.s3.multipart.part_lister(self._multipart):
-                  part_count += 1
+                    part_count += 1
                 if part_count == chunk_count:
                     self._multipart.complete_upload()
                     key = self.bucket.get_key(key_name)

--- a/mongodb_consistent_backup/Upload/S3/S3Session.py
+++ b/mongodb_consistent_backup/Upload/S3/S3Session.py
@@ -6,6 +6,7 @@ from boto.s3.connection import OrdinaryCallingFormat, SubdomainCallingFormat
 
 from mongodb_consistent_backup.Errors import OperationError
 
+
 class S3Session:
     def __init__(self, region, access_key, secret_key, bucket_name, secure=True, num_retries=5, socket_timeout=15):
         self.region         = region

--- a/mongodb_consistent_backup/Upload/S3/__init__.py
+++ b/mongodb_consistent_backup/Upload/S3/__init__.py
@@ -1,4 +1,5 @@
-from S3 import S3
+from S3 import S3  # NOQA
+
 
 def config(parser):
     parser.add_argument("--upload.s3.region", dest="upload.s3.region", help="S3 Uploader AWS region to connect to (default: us-east-1)", default="us-east-1", type=str)

--- a/mongodb_consistent_backup/Upload/Upload.py
+++ b/mongodb_consistent_backup/Upload/Upload.py
@@ -1,5 +1,5 @@
-from mongodb_consistent_backup.Upload.Gs import Gs
-from mongodb_consistent_backup.Upload.S3 import S3
+from mongodb_consistent_backup.Upload.Gs import Gs  # NOQA
+from mongodb_consistent_backup.Upload.S3 import S3  # NOQA
 from mongodb_consistent_backup.Pipeline import Stage
 
 

--- a/mongodb_consistent_backup/Upload/__init__.py
+++ b/mongodb_consistent_backup/Upload/__init__.py
@@ -1,7 +1,7 @@
-from Upload import Upload
+from Upload import Upload  # NOQA
 
 
 def config(parser):
     parser.add_argument("--upload.method", dest="upload.method", help="Uploader method (default: none)", default='none', choices=['gs', 's3', 'none'])
-    parser.add_argument("--upload.remove_uploaded", dest="upload.remove_uploaded",help="Remove source files after successful upload (default: false)", default=False, action="store_true")
+    parser.add_argument("--upload.remove_uploaded", dest="upload.remove_uploaded", help="Remove source files after successful upload (default: false)", default=False, action="store_true")
     return parser

--- a/mongodb_consistent_backup/__init__.py
+++ b/mongodb_consistent_backup/__init__.py
@@ -8,6 +8,7 @@ __version__ = "#.#.#"
 git_commit  = 'GIT_COMMIT_HASH'
 prog_name   = 'mongodb-consistent-backup'
 
+
 # noinspection PyUnusedLocal
 def run():
     try:


### PR DESCRIPTION
This PR moves the code to adhering to flake8 with these ignored/exception codes (for now):

1. E221 multiple spaces before operator = because we align equals-signs and dict colons (=/:) in the code.
2. E241 multiple spaces after ':' = same thing as E221.
3. E501 line too long = this is valid and should be fixed but one step at a time.

NOTE: "# NOQA" tags are added to our dynamic imports that cause flake8 issues. Due to the way we dynamically load our modules I don't think this can be avoided. "# NOQA" causes flake8 to ignore the problem in these cases.

The fixes in this PR were mostly:

1. Functions/modules imported but not used.
2. Variables set but not used.
3. Whitespace issues.
4. In a few cases Error-types used but not imported.
5. 'if !=' to 'if not' style fixes.

After this is done we can do flake8 checks in travis-ci (after #197 is reviewed/merged)