### PR TITLE
Fix flake8cleanup breakage from #198

### DIFF
--- a/mongodb_consistent_backup/Archive/Archive.py
+++ b/mongodb_consistent_backup/Archive/Archive.py
@@ -1,3 +1,5 @@
+from mongodb_consistent_backup.Archive.Tar import Tar  # NOQA
+from mongodb_consistent_backup.Archive.Zbackup import Zbackup  # NOQA
 from mongodb_consistent_backup.Pipeline import Stage
 
 


### PR DESCRIPTION
This adds back 2 x imports that were removed in the flake8 cleanup by accident (PR #198). They're removal has caused the Archive stage to break the entire backup.

This was not caught by Travis CI because of a problem with our Docker build that is resolved in #201.