### PR TITLE
1.2.0: Update PyPi requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 multiprocessing
-Fabric==1.13.2
-pymongo==3.4.0
+Fabric==1.14.0
+pymongo==3.5.1
 pynsca==1.5
 PyYAML==3.12
-boto==2.47.0
+boto==2.48.0
 filechunkio==1.8
-python-dateutil==2.2
+python-dateutil==2.6.1
 yconf==0.3.4
-google_compute_engine
+google_compute_engine==2.6.0


### PR DESCRIPTION
Updates to latest-stable PyPi dependencies:
- Fabric 1.13.2 -> 1.14.0
- Pymongo 3.4.0 -> 3.5.1
- Boto 2.47.0 -> 2.48.0
- Python-dateutil 2.2 -> 2.6.1
- google_compute_engine -> 2.6.0.