### PR TITLE
Ensure openssl-libs are required in RPM (for SSL support), add missing BuildRequires

### DIFF
--- a/scripts/mongodb_consistent_backup.spec
+++ b/scripts/mongodb_consistent_backup.spec
@@ -20,12 +20,12 @@ Source3:	README.rst
 Prefix:		/usr
 
 # Use CentOS SCL python27 (https://www.softwarecollections.org/en/scls/rhscl/python27/) on CentOS 6 (RHEL6 untested)
-# On build host: 'yum install python27-python python27-python-devel python27-python-virtualenv gcc'
+# On build host: 'yum install python27-python python27-python-devel python27-python-virtualenv gcc make libffi-devel openssl-devel'
 %{?el6:Requires: python27-python openssl-libs}
 %{?el6:BuildRequires: python27-python python27-python-devel python27-python-virtualenv gcc make libffi-devel openssl-devel}
 
 # Use base python/virtualenv, which should be 2.7 on CentOS/RHEL 7
-# On build host: 'yum install python python-devel python-virtualenv gcc'
+# On build host: 'yum install python python-devel python-virtualenv gcc make libffi-devel openssl-devel'
 %{?el7:Requires: python >= 2.7 openssl-libs}
 %{?el7:BuildRequires: python >= 2.7 python-devel >= 2.7 python-virtualenv gcc make libffi-devel openssl-devel}
 

--- a/scripts/mongodb_consistent_backup.spec
+++ b/scripts/mongodb_consistent_backup.spec
@@ -21,13 +21,13 @@ Prefix:		/usr
 
 # Use CentOS SCL python27 (https://www.softwarecollections.org/en/scls/rhscl/python27/) on CentOS 6 (RHEL6 untested)
 # On build host: 'yum install python27-python python27-python-devel python27-python-virtualenv gcc'
-%{?el6:Requires: python27-python}
-%{?el6:BuildRequires: python27-python python27-python-devel python27-python-virtualenv gcc}
+%{?el6:Requires: python27-python openssl-libs}
+%{?el6:BuildRequires: python27-python python27-python-devel python27-python-virtualenv gcc make libffi-devel openssl-devel}
 
 # Use base python/virtualenv, which should be 2.7 on CentOS/RHEL 7
 # On build host: 'yum install python python-devel python-virtualenv gcc'
-%{?el7:Requires: python >= 2.7}
-%{?el7:BuildRequires: python >= 2.7 python-devel >= 2.7 python-virtualenv gcc}
+%{?el7:Requires: python >= 2.7 openssl-libs}
+%{?el7:BuildRequires: python >= 2.7 python-devel >= 2.7 python-virtualenv gcc make libffi-devel openssl-devel}
 
 
 %description


### PR DESCRIPTION
1. Ensure openssl-libs is an RPM Require: (we support SSL after #208 and pymongo calls libssl). This may already be auto-discovered at RPM build-time so this is playing it safe.
2. Adding missing BuildRequires (make, openssl-devel and libffi-devel) to RPM spec.