### PR TITLE
1.2.0: Fix for replication.max_lag_secs Issue #177

### DIFF
--- a/mongodb_consistent_backup/Replication/Replset.py
+++ b/mongodb_consistent_backup/Replication/Replset.py
@@ -12,13 +12,16 @@ class Replset:
     def __init__(self, config, db):
         self.config       = config
         self.db           = db
-        self.max_lag_secs = self.config.replication.max_lag_secs
-        self.min_priority = self.config.replication.min_priority
-        self.max_priority = self.config.replication.max_priority
+        self.max_lag_secs = int(self.config.replication.max_lag_secs)
+        self.min_priority = int(self.config.replication.min_priority)
+        self.max_priority = int(self.config.replication.max_priority)
         self.hidden_only  = self.config.replication.hidden_only
 
-        self.hidden_weight = 0.20
-        self.pri0_weight   = 0.10
+        self.state_primary   = 1
+        self.state_secondary = 2
+        self.state_arbiter   = 7
+        self.hidden_weight   = 0.20
+        self.pri0_weight     = 0.10
 
         self.replset      = True
         self.rs_config    = None
@@ -144,7 +147,7 @@ class Replset:
             rs_status = self.get_rs_status(force, quiet)
             rs_name   = rs_status['set']
             for member in rs_status['members']:
-                if member['stateStr'] == 'PRIMARY' and member['health'] > 0:
+                if member['state'] == self.state_primary and member['health'] > 0:
                     member_uri = MongoUri(member['name'], 27017, rs_name)
                     optime_ts  = member['optime']
                     if isinstance(member['optime'], dict) and 'ts' in member['optime']:
@@ -184,11 +187,11 @@ class Replset:
             if self.is_member_electable(member_config):
                 electable_count += 1
 
-            if member['state'] == 7:
+            if member['state'] == self.state_arbiter:
                 logging.info("Found ARBITER %s, skipping" % member_uri)
-            elif member['state'] > 2:
+            elif member['state'] > self.state_secondary:
                 logging.warning("Found down or unhealthy SECONDARY %s with state: %s" % (member_uri, member['stateStr']))
-            elif member['state'] == 2 and member['health'] > 0:
+            elif member['state'] == self.state_secondary and member['health'] > 0:
                 log_data    = {}
                 score       = self.max_lag_secs * 10
                 score_scale = 100 / score
@@ -223,6 +226,10 @@ class Replset:
                     log_msg = "Found SECONDARY %s" % member_uri
                 else:
                     log_msg = "Found SECONDARY %s with too high replication lag! Skipping" % member_uri
+
+                if self.secondary['score'] == 0:
+                    logging.error("Chosen SECONDARY %s has a score of zero/0! This is unexpected, exiting" % member_uri)
+                    raise OperationError("Chosen SECONDARY %s has a score of zero/0!" % member_uri)
 
                 if 'configsvr' in rs_status and rs_status['configsvr']:
                     log_data['configsvr'] = True

--- a/mongodb_consistent_backup/Replication/Replset.py
+++ b/mongodb_consistent_backup/Replication/Replset.py
@@ -12,9 +12,9 @@ class Replset:
     def __init__(self, config, db):
         self.config       = config
         self.db           = db
-        self.max_lag_secs = int(self.config.replication.max_lag_secs)
-        self.min_priority = int(self.config.replication.min_priority)
-        self.max_priority = int(self.config.replication.max_priority)
+        self.max_lag_secs = self.config.replication.max_lag_secs
+        self.min_priority = self.config.replication.min_priority
+        self.max_priority = self.config.replication.max_priority
         self.hidden_only  = self.config.replication.hidden_only
 
         self.state_primary   = 1

--- a/mongodb_consistent_backup/Replication/Replset.py
+++ b/mongodb_consistent_backup/Replication/Replset.py
@@ -194,7 +194,7 @@ class Replset:
             elif member['state'] == self.state_secondary and member['health'] > 0:
                 log_data    = {}
                 score       = self.max_lag_secs * 10
-                score_scale = 100 / score
+                score_scale = 100.00 / float(score)
                 priority    = 0
                 if 'hidden' in member_config and member_config['hidden']:
                     score += (score * self.hidden_weight)


### PR DESCRIPTION
1. Make sure the score multiplier is a float. It breaks when using numbers larger than 10 (#177).
2. Throw exception if the winning backup secondary has score zero/0 to prevent any other issues selecting the wrong node in the future.
3. Create constants for MongoDB replset state integers to clean up code.

Resolves issue #177.