### PR TITLE
Fix S3 upload bug

### DIFF
--- a/mongodb_consistent_backup/Upload/S3/S3.py
+++ b/mongodb_consistent_backup/Upload/S3/S3.py
@@ -111,9 +111,7 @@ class S3(Task):
                         try:
                             self.bucket.set_acl(self.s3_acl, key_name)
                         except Exception as ex:
-                            logging.warn("Unable to set ACLs on uploaded key. Exception: {}".format(str(ex)))
-                            import traceback
-                            logging.warn(traceback.print_exc())
+                            logging.exception("Unable to set ACLs on uploaded key: {}.".format(key_name))
                     self._upload_done = True
 
                     if self.remove_uploaded:

--- a/mongodb_consistent_backup/Upload/S3/S3.py
+++ b/mongodb_consistent_backup/Upload/S3/S3.py
@@ -110,7 +110,7 @@ class S3(Task):
                     if self.s3_acl:
                         try:
                             self.bucket.set_acl(self.s3_acl, key_name)
-                        except Exception as ex:
+                        except Exception:
                             logging.exception("Unable to set ACLs on uploaded key: {}.".format(key_name))
                     self._upload_done = True
 

--- a/mongodb_consistent_backup/Upload/S3/S3.py
+++ b/mongodb_consistent_backup/Upload/S3/S3.py
@@ -107,9 +107,13 @@ class S3(Task):
                     part_count += 1
                 if part_count == chunk_count:
                     self._multipart.complete_upload()
-                    key = self.bucket.get_key(key_name)
                     if self.s3_acl:
-                        key.set_acl(self.s3_acl)
+                        try:
+                            self.bucket.set_acl(self.s3_acl, key_name)
+                        except Exception as ex:
+                            logging.warn("Unable to set ACLs on uploaded key. Exception: {}".format(str(ex)))
+                            import traceback
+                            logging.warn(traceback.print_exc())
                     self._upload_done = True
 
                     if self.remove_uploaded:


### PR DESCRIPTION
Proposed fix for: https://github.com/Percona-Lab/mongodb_consistent_backup/issues/187

This fix has a couple of parts. First, it gets rid of the `get_key` call, which is not necessary for setting the ACL. In our tests, an exception in this `get_key` call caused the entire upload to fail, which is probably NOT the desired result.

Secondly, this fix uses the `set_acl` directly on the S3 Bucket object (http://boto.cloudhackers.com/en/latest/ref/s3.html#boto.s3.bucket.Bucket.set_acl). This allows us to avoid the problematic `get_key` call.

Finally, the exception was blank in our testing. This fix adds an explicit call to `traceback` to help clarify the cause of the error.