### PR TITLE
1.2.0 README + Config Default Typo fixes v2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,7 @@ Features
    notification support (*optional*)
 -  Modular backup, archiving, upload and notification components
 -  Support for MongoDB Authentication and SSL database connections
+-  Support for Read Preference Tags for selecting specific nodes for backup
 -  Rotation of backups by time or count
 -  Multi-threaded, single executable
 -  Auto-scales to number of available CPUs by default
@@ -80,7 +81,7 @@ To build an CentOS/RedHat RPM of the tool *(recommended)*:
 ::
 
     $ cd /path/to/mongodb_consistent_backup
-    $ sudo yum install -y rpm-build
+    $ yum install -y rpm-build
     $ make rpm
 
 To build and install from source *(to default '/usr/local/bin/mongodb-consistent-backup')*:
@@ -235,7 +236,9 @@ Roadmap
 
 -  More testing: this project has many flows that probably need more in-depth testing. Please submit any bugs and/or bugfixes!
 -  "Distributed Mode" for running backup on remote hosts *(vs. only on one host)*
+-  Binary backup methods *(createBackup/Hot Backup, LVM and EBS snapshots, etc)*
 -  Upload compatibility for ZBackup archive phase *(upload unsupported today)*
+-  Support Upload with Backup Rotation *(rotated backups are not deleted on upload destination)*
 -  Support more notification methods *(Prometheus, PagerDuty, etc)*
 -  Python unit tests
 

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,6 @@ Features
 -  `Nagios NSCA <https://sourceforge.net/p/nagios/nsca>`__ push
    notification support (*optional*)
 -  Modular backup, archiving, upload and notification components
--  Rotation of backups by time or count
 -  Support for MongoDB Authentication and SSL database connections
 -  Support for Read Preference Tags for selecting specific nodes for backup
 -  Rotation of backups by time or count

--- a/conf/mongodb-consistent-backup.example.conf
+++ b/conf/mongodb-consistent-backup.example.conf
@@ -18,10 +18,10 @@ production:
   #  mongodump:
   #    binary: [path]                (default: /usr/bin/mongodump)
   #    compression: [auto|none|gzip] (default: auto - enable gzip if supported)
+  #    threads: [1-16]               (default: auto-generated, shards/cpu)
   #rotate:
   #  max_backups: [1+]
   #  max_days: [0.1+]
-  #    threads: [1-16]               (default: auto-generated, shards/cpu)
   #replication:
   #  max_lag_secs: [1+]                        (default: 10)
   #  min_priority: [0-999]                     (default: 0)

--- a/mongodb_consistent_backup/Oplog/__init__.py
+++ b/mongodb_consistent_backup/Oplog/__init__.py
@@ -6,7 +6,7 @@ from Tailer import Tailer  # NOQA
 
 def config(parser):
     parser.add_argument("--oplog.compression", dest="oplog.compression", help="Compression method to use on captured oplog file (default: none)", choices=["none", "gzip"], default="none")
-    parser.add_argument("--oplog.flush.max_docs", dest="oplog.flush.max_docs", help="Maximum number of oplog document writes to trigger a flush of the backup oplog file (default: 1000)", default=1000, type=int)
+    parser.add_argument("--oplog.flush.max_docs", dest="oplog.flush.max_docs", help="Maximum number of oplog document writes to trigger a flush of the backup oplog file (default: 100)", default=100, type=int)
     parser.add_argument("--oplog.flush.max_secs", dest="oplog.flush.max_secs", help="Number of seconds to wait to flush the backup oplog file, if 'max_docs' is not reached (default: 1)", default=1, type=int)
     parser.add_argument("--oplog.resolver.threads", dest="oplog.resolver.threads", help="Number of threads to use during resolver step (default: 1-per-CPU)", default=0, type=int)
     parser.add_argument("--oplog.tailer.enabled", dest="oplog.tailer.enabled", help="Enable/disable capturing of cluster-consistent oplogs, required for cluster-wide PITR (default: true)", default='true', type=str)


### PR DESCRIPTION
1. Remove 'sudo' from rpm-build yum command, all other yum commands don't specify sudo.
2. Add updates for new features.
3. Remove duplicate line "Rotation of backups by time or count".
4. Clean up typos in config file example.