### PR TITLE
Fix: 'MongodumpThread' object has no attribute 'client_cert_file'

### DIFF
--- a/mongodb_consistent_backup/Backup/Mongodump/MongodumpThread.py
+++ b/mongodb_consistent_backup/Backup/Mongodump/MongodumpThread.py
@@ -189,7 +189,7 @@ class MongodumpThread(Process):
                     mongodump_flags.append("--sslCAFile=%s" % self.ssl_ca_file)
                 if self.ssl_crl_file:
                     mongodump_flags.append("--sslCRLFile=%s" % self.ssl_crl_file)
-                if self.client_cert_file:
+                if self.ssl_client_cert_file:
                     mongodump_flags.append("--sslPEMKeyFile=%s" % self.ssl_cert_file)
                 if self.do_ssl_insecure():
                     mongodump_flags.extend(["--sslAllowInvalidCertificates", "--sslAllowInvalidHostnames"])


### PR DESCRIPTION
Without this fix will always fail on "'MongodumpThread' object has no attribute 'client_cert_file'" when using SSL connected MongoDB