### PR TITLE
Update to Pymongo 3.6.0 and latest GCE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 multiprocessing
 Fabric==1.14.0
-pymongo==3.5.1
+pymongo==3.6.0
 pynsca==1.5
 PyYAML==3.12
 boto==2.48.0
 filechunkio==1.8
 python-dateutil==2.6.1
 yconf==0.3.4
-google_compute_engine==2.6.0
+google_compute_engine==2.7.2


### PR DESCRIPTION
This is to ensure compat with MongoDB 3.6.0+. I bumped GCE while I was there, the rest are latest.