### PR TITLE
pull request for issue #259

### DIFF
--- a/mongodb_consistent_backup/Upload/S3/S3.py
+++ b/mongodb_consistent_backup/Upload/S3/S3.py
@@ -27,8 +27,8 @@ class S3(Task):
 
         self._pool = None
 
-        if None in (self.access_key, self.secret_key, self.region):
-            raise OperationError("Invalid or missing AWS S3 access key, secret key or region detected!")
+        if None in (self.region):
+            raise OperationError("Invalid or missing AWS S3 region detected!")
 
         self._pool = S3UploadPool(
             self.bucket_name,

--- a/mongodb_consistent_backup/Upload/S3/S3.py
+++ b/mongodb_consistent_backup/Upload/S3/S3.py
@@ -27,7 +27,7 @@ class S3(Task):
 
         self._pool = None
 
-        if None in (self.region):
+        if self.region is None:
             raise OperationError("Invalid or missing AWS S3 region detected!")
 
         self._pool = S3UploadPool(

--- a/mongodb_consistent_backup/Upload/S3/S3Session.py
+++ b/mongodb_consistent_backup/Upload/S3/S3Session.py
@@ -46,15 +46,24 @@ class S3Session:
     def connect(self):
         if not self._conn:
             try:
-                logging.debug("Connecting to AWS S3 with Access Key: %s" % self.access_key)
-                self._conn = boto.s3.connect_to_region(
-                    self.region,
-                    aws_access_key_id=self.access_key,
-                    aws_secret_access_key=self.secret_key,
-                    is_secure=self.secure,
-                    calling_format=self.calling_format
-                )
-                logging.debug("Successfully connected to AWS S3 with Access Key: %s" % self.access_key)
+                if (self.access_key is not None and self.secret_key is not None):
+                    logging.debug("Connecting to AWS S3 with Access Key: %s" % self.access_key)
+                    self._conn = boto.s3.connect_to_region(
+                        self.region,
+                        aws_access_key_id=self.access_key,
+                        aws_secret_access_key=self.secret_key,
+                        is_secure=self.secure,
+                        calling_format=self.calling_format
+                    )
+                    logging.debug("Successfully connected to AWS S3 with Access Key: %s" % self.access_key)
+                else:
+                    logging.debug("Connecting to AWS S3 with IAM Role")
+                    self._conn = boto.s3.connect_to_region(
+                        self.region,
+                        is_secure=self.secure,
+                        calling_format=self.calling_format
+                    )
+                    logging.debug("Successfully connected to AWS S3 with IAM Role")
             except boto.exception.S3ResponseError, e:
                 if self.is_forbidden_error(e):
                     logging.error("Not authorized to connect to AWS S3 with Access Key: %s!" % self.access_key)


### PR DESCRIPTION
Implements the ability to use embedded iam credentials in an EC2 instance

I reported this in issue #259 
https://github.com/Percona-Lab/mongodb_consistent_backup/issues/259

Tests passed:
- Flake8
- Uploading with IAM embedded role
- Uplaoding with explicit AWS access and secret keys


regards