### PR TITLE
Feature: Add Zabbix Server notification support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,7 @@ Features
 -  Rsync (over SSH) secure backup uploads (*optional*)
 -  `Nagios NSCA <https://sourceforge.net/p/nagios/nsca>`__ push
    notification support (*optional*)
+- `Zabbix <https://www.zabbix.com/>`__ sender notification support (*optional*)
 -  Modular backup, archiving, upload and notification components
 -  Support for MongoDB Authentication and SSL database connections
 -  Support for Read Preference Tags for selecting specific nodes for backup

--- a/conf/mongodb-consistent-backup.example.conf
+++ b/conf/mongodb-consistent-backup.example.conf
@@ -61,7 +61,7 @@ production:
   #    check_host: [nagios host]
   #    check_name: [nagios check name]
   #  zabbix:
-  #    use_config: true
+  #    use_config: true (If zabbix-agent is installed, use its config)
   #    server: [zabbix host] (unused if use_config == true. default: 127.0.0.1)
   #    port: [zabbix port] (unused if use_config == true. default: 10051)
   #    node: [zabbix node display name] (default: node hostname)

--- a/conf/mongodb-consistent-backup.example.conf
+++ b/conf/mongodb-consistent-backup.example.conf
@@ -60,6 +60,12 @@ production:
   #    password: [password]
   #    check_host: [nagios host]
   #    check_name: [nagios check name]
+  #  zabbix:
+  #    use_config: true
+  #    server: [zabbix host] (unused if use_config == true. default: 127.0.0.1)
+  #    port: [zabbix port] (unused if use_config == true. default: 10051)
+  #    node: [zabbix node display name] (default: node hostname)
+  #    key: [zabbix item key]
   upload:
     method: none
   #  remove_uploaded: [true|false] (default: false)

--- a/mongodb_consistent_backup/Notify/Zabbix/Zabbix.py
+++ b/mongodb_consistent_backup/Notify/Zabbix/Zabbix.py
@@ -1,0 +1,60 @@
+import logging
+import sys
+
+from pyzabbix import ZabbixMetric, ZabbixSender
+
+from mongodb_consistent_backup.Errors import NotifyError, OperationError
+from mongodb_consistent_backup.Pipeline import Task
+
+
+class Zabbix(Task):
+    def __init__(self, manager, config, timer, base_dir, backup_dir, **kwargs):
+        super(Zabbix, self).__init__(self.__class__.__name__, manager, config, timer, base_dir, backup_dir, **kwargs)
+        self.zabbix_server     = self.config.notify.zabbix.server
+        self.zabbix_port       = self.config.notify.zabbix.port
+        self.zabbix_use_config = self.config.notify.zabbix.use_config
+        self.zabbix_key        = self.config.notify.zabbix.key
+        self.zabbix_nodename   = self.config.notify.zabbix.node
+
+        req_attrs = ['zabbix_key']
+        for attr in req_attrs:
+            if not getattr(self, attr):
+                raise OperationError('Zabbix notifier module requires attribute: %s!' % attr)
+
+        try:
+            self.notifier = ZabbixSender(
+                use_config=self.zabbix_use_config,
+                zabbix_server=self.zabbix_server,
+                zabbix_port=self.zabbix_port,
+            )
+        except Exception, e:
+            logging.error("Error initiating ZabbixSender! Error: %s" % e)
+            raise OperationError(e)
+
+    def close(self):
+        pass
+
+    def run(self, ret_code):
+        if self.notifier:
+            logging.info("Sending Zabbix metric to item '%s:%s' to Zabbix Server" % (
+                self.zabbix_nodename,
+                self.zabbix_key,
+            ))
+            logging.debug("Zabbix metric return code: '%s', item key: '%s', node name: '%s'" % (ret_code, self.zabbix_key, self.zabbix_nodename))
+
+            try:
+                metrics = [ZabbixMetric(self.zabbix_nodename, self.zabbix_key, ret_code)]
+                response = self.notifier.send(metrics)
+
+                if response.failed > 0:
+                    raise NotifyError("%s metric(s) failed out of %s" % (response.failed, response.total))
+            except Exception, e:
+                logging.error("Failed to send Zabbix metric to host" % (sys.exc_info()[1]))
+                raise NotifyError(e)
+            finally:
+                logging.info("Zabbix report processed. Processed: %s, Failed: %s, Total: %s, Seconds spent: %s" % (
+                    response.processed,
+                    response.failed,
+                    response.total,
+                    response.time
+                ))

--- a/mongodb_consistent_backup/Notify/Zabbix/__init__.py
+++ b/mongodb_consistent_backup/Notify/Zabbix/__init__.py
@@ -1,0 +1,19 @@
+import socket
+
+
+def config(parser):
+    parser.add_argument("--notify.zabbix.use_config", dest="notify.zabbix.use_config",
+                        help="Use Zabbix Agent configuration (default: True)",
+                        default=True, choices=[True, False])
+    parser.add_argument("--notify.zabbix.server", dest="notify.zabbix.server",
+                        help="Zabbix Server hostname/ip address, not used if notify.zabbix.use_config is True (default: none)",
+                        default='127.0.0.1', type=str)
+    parser.add_argument("--notify.zabbix.port", dest="notify.zabbix.port",
+                        help="Zabbix Server port, not used if notify.zabbix.use_config is True (default: none)",
+                        default=10051, type=int)
+    parser.add_argument("--notify.zabbix.key", dest="notify.zabbix.key",
+                        help="Zabbix Server item key", default=None, type=str)
+    parser.add_argument("--notify.zabbix.node", dest="notify.zabbix.node",
+                        help="Node name monitored by Zabbix Server (default: nodename)",
+                        default=socket.gethostname(), type=str)
+    return parser

--- a/mongodb_consistent_backup/Notify/__init__.py
+++ b/mongodb_consistent_backup/Notify/__init__.py
@@ -2,5 +2,5 @@ from Notify import Notify  # NOQA
 
 
 def config(parser):
-    parser.add_argument("--notify.method", dest="notify.method", help="Notifier method (default: none)", default='none', choices=['nsca', 'none'])
+    parser.add_argument("--notify.method", dest="notify.method", help="Notifier method (default: none)", default='none', choices=['nsca', 'zabbix', 'none'])
     return parser

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python-dateutil==2.6.1
 yconf==0.3.4
 google_compute_engine==2.7.2
 progress==1.3
+py-zabbix==1.1.3


### PR DESCRIPTION
This PR adds a new notify option to Zabbix server. If the Zabbix server is monitoring the node an administrator can add a trapper item to receive the return code from the backup. Advise the administrator to alert if the value is not 0