### PR TITLE
Fixing rpm filename expression for CentOS 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ MAINTAINER Tim Vaillancourt <tim.vaillancourt@percona.com>
 RUN yum install -y https://www.percona.com/redir/downloads/percona-release/redhat/latest/percona-release-0.1-4.noarch.rpm epel-release && \
 	yum install -y Percona-Server-MongoDB-34-tools zbackup && yum clean all
 
-ADD build/rpm/RPMS/x86_64/mongodb_consistent_backup*.el*.centos.x86_64.rpm /
-RUN yum localinstall -y /mongodb_consistent_backup*.el*.centos.x86_64.rpm && \
-	yum clean all && rm -f /mongodb_consistent_backup*.el*.centos.x86_64.rpm
+ADD build/rpm/RPMS/x86_64/mongodb_consistent_backup*.el7.x86_64.rpm /
+RUN yum localinstall -y /mongodb_consistent_backup*.el7.x86_64.rpm && \
+	yum clean all && rm -f /mongodb_consistent_backup*.el7.x86_64.rpm
 
 USER mongodb_consistent_backup
 ENTRYPOINT ["mongodb-consistent-backup"]

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ uninstall:
 	rm -rf $(SHAREDIR)/$(NAME)
 
 # Build CentOS7 RPM (in Docker)
-build/rpm/RPMS/$(ARCH)/$(NAME)-$(VERSION)-$(RELEASE).el7.centos.$(ARCH).rpm:
+build/rpm/RPMS/$(ARCH)/$(NAME)-$(VERSION)-$(RELEASE).el7.$(ARCH).rpm:
 	mkdir -p $(MAKE_DIR)/build/rpm/RPMS/$(ARCH)
 	docker run --rm \
 		-v "$(MAKE_DIR)/bin:/src/bin:Z" \
@@ -60,10 +60,10 @@ build/rpm/RPMS/$(ARCH)/$(NAME)-$(VERSION)-$(RELEASE).el7.centos.$(ARCH).rpm:
 		-v "$(MAKE_DIR)/build/rpm/RPMS/$(ARCH):/src/build/rpm/RPMS/$(ARCH):Z" \
 		-i centos:centos7 \
 		/bin/bash -c "yum install -y python-devel python-virtualenv gcc make libffi-devel openssl-devel rpm-build && \
-			make -C /src RELEASE=$(RELEASE) GIT_COMMIT=$(GIT_COMMIT) BIN_NAME=mongodb-consistent-backup.el7.centos.$(ARCH) rpm && \
-			/src/bin/mongodb-consistent-backup.el7.centos.$(ARCH) --version"
+			make -C /src RELEASE=$(RELEASE) GIT_COMMIT=$(GIT_COMMIT) BIN_NAME=mongodb-consistent-backup.el7.$(ARCH) rpm && \
+			/src/bin/mongodb-consistent-backup.el7.$(ARCH) --version"
 
-centos7: build/rpm/RPMS/$(ARCH)/$(NAME)-$(VERSION)-1.el7.centos.$(ARCH).rpm
+centos7: build/rpm/RPMS/$(ARCH)/$(NAME)-$(VERSION)-1.el7.$(ARCH).rpm
 
 # Build Debian8 Binary (in Docker - .deb package soon!)
 bin/mongodb-consistent-backup.debian8.$(ARCH):
@@ -109,7 +109,7 @@ bin/mongodb-consistent-backup.debian9.$(ARCH):
 
 debian9: bin/mongodb-consistent-backup.debian9.$(ARCH)
 
-docker: build/rpm/RPMS/$(ARCH)/$(NAME)-$(VERSION)-$(RELEASE).el7.centos.$(ARCH).rpm
+docker: build/rpm/RPMS/$(ARCH)/$(NAME)-$(VERSION)-$(RELEASE).el7.$(ARCH).rpm
 	docker build --no-cache --tag $(DOCKER_TAG) .
 	docker tag $(DOCKER_TAG) $(NAME):latest
 	docker run --rm -i $(DOCKER_TAG) --version


### PR DESCRIPTION
RPMs for CentOS 7 are not named *.el7.centos.$arch. They are named *.el7.$arch