### PR TITLE
Rotate: Wrapping the rotate removal under a try-catch block.

### DIFF
--- a/mongodb_consistent_backup/Rotate.py
+++ b/mongodb_consistent_backup/Rotate.py
@@ -43,11 +43,11 @@ class Rotate(object):
     def remove(self, ts):
         if ts in self.backups:
             backup = self.backups[ts]
-            if os.path.isdir(backup["path"]):
+            try:
                 logging.debug("Removing backup path: %s" % backup["path"])
                 rmtree(backup["path"])
-            else:
-                raise OperationError("Backup path %s does not exist!" % backup["path"])
+            except Exception, e:
+                raise OperationError("Unable to remove backup path %s. %s" % backup["path"], e)
             if self.previous == backup:
                 self.previous = None
             del self.backups[ts]


### PR DESCRIPTION
The original code would raise an OperationError is the backup path doesn't exist. This is not the only reason a rmtree would fail, insufficient permissions, invalid SELinux contexts, etc.
This commit wraps the rmtree functionality in a try-catch block to catch and log any exceptions that may happen.