### PR TITLE
Oplog/Resolver/Resolver.py: De-duplicating code closing the pool

### DIFF
--- a/mongodb_consistent_backup/Oplog/Resolver/Resolver.py
+++ b/mongodb_consistent_backup/Oplog/Resolver/Resolver.py
@@ -50,8 +50,8 @@ class Resolver(Task):
             logging.fatal("Could not start oplog resolver pool! Error: %s" % e)
             raise Error(e)
 
-    def close(self, code=None, frame=None):
-        if self._pool and not self.stopped:
+    def close(self):
+        if self._pool and self.stopped:
             logging.debug("Stopping all oplog resolver threads")
             self._pool.terminate()
             logging.info("Stopped all oplog resolver threads")
@@ -102,10 +102,6 @@ class Resolver(Task):
                         waited_secs += poll_secs
                     else:
                         raise OperationError("Waited more than %i seconds for Oplog resolver! I will assume there is a problem and exit")
-            self._pool.terminate()
-            logging.debug("Stopped all oplog resolver threads")
-            self.stopped = True
-            self.running = False
 
     def run(self):
         try:


### PR DESCRIPTION
The close() function is already being called at the end of the stage. The same code present in wait() is needless duplication. This commit removes the duplicated code from wait() and a slight change in the conditions in close().

It is unknown if this contributes to #277 but at the very least this reduces the attack surface.