### PR TITLE
Fix building on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 tmp
 *.pyc
 .idea
+*.iml

--- a/mongodb_consistent_backup/Upload/Rsync/Rsync.py
+++ b/mongodb_consistent_backup/Upload/Rsync/Rsync.py
@@ -56,7 +56,7 @@ class Rsync(Task):
     def rsync_info(self):
         if not self._rsync_info:
             output = check_output([self.rsync_binary, "--version"])
-            search = re.search("^rsync\s+version\s([0-9.-]+)\s+protocol\sversion\s(\d+)", output)
+            search = re.search(r"^rsync\s+version\s([0-9.-]+)\s+protocol\sversion\s(\d+)", output)
             self.rsync_version = search.group(1)
             self._rsync_info   = {"version": self.rsync_version, "protocol_version": int(search.group(2))}
         return self._rsync_info

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,9 +2,21 @@
 
 set -x
 
+readlink_bin=readlink
+cp_bin=cp
+if [[ "`uname`" =~ "Darwin" ]]; then
+	if [[ -x /usr/local/bin/gcp && -x /usr/local/bin/greadlink ]]; then
+		readlink_bin=greadlink
+		cp_bin=gcp
+	else
+		echo "To run this on macOS, please install coreutils via homebrew first."
+		exit 1
+	fi
+fi
+
 name=${BIN_NAME:-mongodb-consistent-backup}
 mod_name=mongodb_consistent_backup
-rootdir=$(readlink -f $(dirname $0)/..)
+rootdir=$(${readlink_bin} -f $(dirname $0)/..)
 srcdir=${rootdir}/${mod_name}
 bindir=${rootdir}/bin
 builddir=${rootdir}/build
@@ -55,8 +67,8 @@ fi
 if [ -d ${srcdir} ]; then
 	[ -e ${builddir} ] && rm -rf ${builddir}
 	mkdir -p ${builddir}
-	cp -dpR ${rootdir}/${mod_name} ${builddir}/${mod_name}
-	cp -dp ${rootdir}/{setup.py,requirements.txt,README.rst,VERSION} ${builddir}
+	${cp_bin} -dpR ${rootdir}/${mod_name} ${builddir}/${mod_name}
+	${cp_bin} -dp ${rootdir}/{setup.py,requirements.txt,README.rst,VERSION} ${builddir}
 	find ${builddir} -type f -name "*.pyc" -delete
 
 	# Replace version number in setup.py and mongodb_consistent_backup/__init__.py with number in VERSION:


### PR DESCRIPTION
There already was a switch in place for the Python executable, but both the
`readlink` and `cp` commands use flags not present on the default macOS binaries.

This commit adds a check upfront and aborts with a message about you needing
the `coreutils` package from homebrew to get the GNU variants of both commands.

As a small additional change I added a new entry for IntelliJ module files to .gitignore.