### PR TITLE
Option to Allow skipping bucket validation

### DIFF
--- a/mongodb_consistent_backup/Upload/Rsync/Rsync.py
+++ b/mongodb_consistent_backup/Upload/Rsync/Rsync.py
@@ -56,7 +56,7 @@ class Rsync(Task):
     def rsync_info(self):
         if not self._rsync_info:
             output = check_output([self.rsync_binary, "--version"])
-            search = re.search("^rsync\s+version\s([0-9.-]+)\s+protocol\sversion\s(\d+)", output)
+            search = re.search(r"^rsync\s+version\s([0-9.-]+)\s+protocol\sversion\s(\d+)", output)
             self.rsync_version = search.group(1)
             self._rsync_info   = {"version": self.rsync_version, "protocol_version": int(search.group(2))}
         return self._rsync_info

--- a/mongodb_consistent_backup/Upload/S3/S3.py
+++ b/mongodb_consistent_backup/Upload/S3/S3.py
@@ -23,6 +23,7 @@ class S3(Task):
         self.chunk_size          = self.chunk_size_mb * 1024 * 1024
         self.s3_acl              = self.config.upload.s3.acl
         self.key_prefix          = base_dir
+        self.validate_bucket     = not self.config.upload.s3.skip_bucket_validation
 
         self.threads(self.config.upload.threads)
         self._pool = None
@@ -38,7 +39,8 @@ class S3(Task):
             self.threads(),
             self.remove_uploaded,
             self.chunk_size,
-            self.s3_acl
+            self.s3_acl,
+            validate_bucket=self.validate_bucket
         )
 
     def get_key_name(self, file_path):

--- a/mongodb_consistent_backup/Upload/S3/S3Session.py
+++ b/mongodb_consistent_backup/Upload/S3/S3Session.py
@@ -79,8 +79,8 @@ class S3Session:
     def get_bucket(self, bucket_name):
         try:
             logging.debug("Connecting to AWS S3 Bucket: %s (%s validation)" % (bucket_name,
-                                                                             "with" if self.validate_bucket
-                                                                             else "without"))
+                                                                               "with" if self.validate_bucket
+                                                                               else "without"))
             return self._conn.get_bucket(bucket_name, validate=self.validate_bucket)
         except boto.exception.S3ResponseError, e:
             if self.is_forbidden_error(e):

--- a/mongodb_consistent_backup/Upload/S3/S3UploadPool.py
+++ b/mongodb_consistent_backup/Upload/S3/S3UploadPool.py
@@ -28,7 +28,7 @@ pickle(MethodType, _reduce_method)
 
 
 class S3UploadPool():
-    def __init__(self, bucket_name, region, access_key, secret_key, threads=4, remove_uploaded=False, chunk_bytes=50 * 1024 * 1024, key_acl=None):
+    def __init__(self, bucket_name, region, access_key, secret_key, threads=4, remove_uploaded=False, chunk_bytes=50 * 1024 * 1024, key_acl=None, **kwargs):
         self.bucket_name     = bucket_name
         self.region          = region
         self.access_key      = access_key
@@ -37,6 +37,7 @@ class S3UploadPool():
         self.remove_uploaded = remove_uploaded
         self.chunk_bytes     = chunk_bytes
         self.key_acl         = key_acl
+        self.validate_bucket = kwargs.get("validate_bucket")
 
         self.multipart_min_bytes = 5242880
 
@@ -46,7 +47,8 @@ class S3UploadPool():
         self._pool       = Pool(processes=self.threads)
 
         try:
-            self.s3_conn = S3Session(self.region, self.access_key, self.secret_key, self.bucket_name)
+            self.s3_conn = S3Session(self.region, self.access_key, self.secret_key, self.bucket_name,
+                                     validate_bucket=self.validate_bucket)
             self.bucket  = self.s3_conn.get_bucket(self.bucket_name)
         except Exception, e:
             raise OperationError(e)

--- a/mongodb_consistent_backup/Upload/S3/__init__.py
+++ b/mongodb_consistent_backup/Upload/S3/__init__.py
@@ -10,6 +10,10 @@ def config(parser):
                         help="S3 Uploader AWS Secret Key (required for S3 upload)")
     parser.add_argument("--upload.s3.bucket_name", dest="upload.s3.bucket_name", type=str,
                         help="S3 Uploader destination bucket name")
+    parser.add_argument("--upload.s3.skip_bucket_validation", dest="upload.s3.skip_bucket_validation", default=False,
+                        action="store_true",
+                        help="S3 Upload will check upfront if the bucket exists. Skip this check if bucket "
+                             "permissions don't allow access to the bucket's root. (default: false)")
     parser.add_argument("--upload.s3.bucket_prefix", dest="upload.s3.bucket_prefix", type=str,
                         help="S3 Uploader destination bucket path prefix")
     parser.add_argument("--upload.s3.bucket_explicit_key", dest="upload.s3.bucket_explicit_key", type=str,


### PR DESCRIPTION
The S3 uploader fails if bucket permissions are restricted to only allow
accessing certain prefixes in a bucket. The default behavior for boto's
`get_bucket()` is to "validate" it by accessing the bucket's root, which it might not
be allowed to, and thereby needlessly breaking the uploader even though all
necessary permissions to actually upload stuff might be present.

This patch adds a new command line switch `--upload.s3.skip_bucket_validation`
to disable this behavior.