### PR TITLE
Deprecate Travis-CI tests of version 3.0 and 3.2 cluster in old/SCCC mode (#233)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,22 +34,10 @@ jobs:
       script:
         - docker load -i $TRAVIS_BUILD_DIR/docker/mongodb_consistent_backup.tar
         - $TRAVIS_BUILD_DIR/scripts/travis-ci/run-cluster.sh 3.2
-#    - stage: test-cluster-3.2-sccc
-#      script:
-#        - docker load -i $TRAVIS_BUILD_DIR/docker/mongodb_consistent_backup.tar
-#        - $TRAVIS_BUILD_DIR/scripts/travis-ci/run-cluster.sh 3.2
     - stage: test-replset-3.2
       script:
         - docker load -i $TRAVIS_BUILD_DIR/docker/mongodb_consistent_backup.tar
         - $TRAVIS_BUILD_DIR/scripts/travis-ci/run-replset.sh 3.2
-#    - stage: test-cluster-3.0
-#      script:
-#        - docker load -i $TRAVIS_BUILD_DIR/docker/mongodb_consistent_backup.tar
-#        - $TRAVIS_BUILD_DIR/scripts/travis-ci/run-cluster.sh 3.0 SCCC
-    - stage: test-replset-3.0
-      script:
-        - docker load -i $TRAVIS_BUILD_DIR/docker/mongodb_consistent_backup.tar
-        - $TRAVIS_BUILD_DIR/scripts/travis-ci/run-replset.sh 3.0
     - stage: test-archive-none
       script:
         - docker load -i $TRAVIS_BUILD_DIR/docker/mongodb_consistent_backup.tar

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:centos7
 MAINTAINER Tim Vaillancourt <tim.vaillancourt@percona.com>
 
 RUN yum install -y https://www.percona.com/redir/downloads/percona-release/redhat/latest/percona-release-0.1-6.noarch.rpm epel-release && \
-	yum install -y Percona-Server-MongoDB-36-tools zbackup && yum clean all
+	yum install -y Percona-Server-MongoDB-34-tools zbackup && yum clean all
 
 ADD build/rpm/RPMS/x86_64/mongodb_consistent_backup*.el7.x86_64.rpm /
 RUN yum localinstall -y /mongodb_consistent_backup*.el7.x86_64.rpm && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:centos7
 MAINTAINER Tim Vaillancourt <tim.vaillancourt@percona.com>
 
 RUN yum install -y https://www.percona.com/redir/downloads/percona-release/redhat/latest/percona-release-0.1-6.noarch.rpm epel-release && \
-	yum install -y Percona-Server-MongoDB-34-tools zbackup && yum clean all
+	yum install -y Percona-Server-MongoDB-36-tools zbackup && yum clean all
 
 ADD build/rpm/RPMS/x86_64/mongodb_consistent_backup*.el7.x86_64.rpm /
 RUN yum localinstall -y /mongodb_consistent_backup*.el7.x86_64.rpm && \


### PR DESCRIPTION
Related to deprecating of 3.0 + 3.2 w/SCCC in #233.