### PR TITLE
 Remove support for non-replset configsvrs (<3.0 and 3.2 w/SCCC) (#233)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,9 @@ Features
    notification support (*optional*)
 - `Zabbix <https://www.zabbix.com/>`__ sender notification support (*optional*)
 -  Modular backup, archiving, upload and notification components
--  Support for MongoDB Authentication and SSL database connections
--  Support for Read Preference Tags for selecting specific nodes for backup
+-  Support for `MongoDB Authentication <https://docs.mongodb.com/manual/core/authentication>`__ and `SSL database connections <https://docs.mongodb.com/manual/core/security-transport-encryption/>`__
+-  Support for `Read Preference Tags <https://docs.mongodb.com/manual/core/read-preference/#tag-sets>`__ for selecting specific nodes for backup
+-  `mongodb+srv:// DNS Seedlist <https://docs.mongodb.com/manual/reference/connection-string/#dns-seedlist-connection-format>`__ support
 -  Rotation of backups by time or count
 -  Multi-threaded, single executable
 -  Auto-scales to number of available CPUs by default
@@ -53,6 +54,7 @@ Current Limitations
 Requirements:
 ~~~~~~~~~~~~~
 
+-  MongoDB / Percona Server for MongoDB 3.2 and above with `Replication <https://docs.mongodb.com/manual/replication>`__ enabled *(including config servers)*
 -  Backup consistency depends on consistent server time across all
    hosts! Server time **must be synchronized on all nodes** using ntpd
    and a consistent time source or virtualization guest agent that 
@@ -232,17 +234,6 @@ To remove a backup, first delete the .tar file in 'backups' subdir of the ZBacku
     $ rm -f /mnt/backup/default/mongodb_consistent_backup-zbackup/backups/20170424_0000.tar
     $ zbackup gc full --password-file /etc/zbackup.passwd /mnt/backup/default/mongodb_consistent_backup-zbackup 
     
-Roadmap
-~~~~~~~
-
--  More testing: this project has many flows that probably need more in-depth testing. Please submit any bugs and/or bugfixes!
--  "Distributed Mode" for running backup on remote hosts *(vs. only on one host)*
--  Binary backup methods *(createBackup/Hot Backup, LVM and EBS snapshots, etc)*
--  Upload compatibility for ZBackup archive phase *(upload unsupported today)*
--  Support Upload with Backup Rotation *(rotated backups are not deleted on upload destination)*
--  Support more notification methods *(Prometheus, PagerDuty, etc)*
--  Python unit tests
-
 Submitting Code
 ~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -54,8 +54,7 @@ Current Limitations
 Requirements:
 ~~~~~~~~~~~~~
 
--  MongoDB / Percona Server for MongoDB 3.2 and above
-    -  `MongoDB Replication <https://docs.mongodb.com/manual/replication>`__ enabled, including sharding config servers
+-  MongoDB / Percona Server for MongoDB 3.2 and above with `Replication <https://docs.mongodb.com/manual/replication>`__ enabled *(sharding config servers included)*
 -  Backup consistency depends on consistent server time across all
    hosts! Server time **must be synchronized on all nodes** using ntpd
    and a consistent time source or virtualization guest agent that 

--- a/README.rst
+++ b/README.rst
@@ -43,9 +43,10 @@ Features
 -  Multi-threaded, single executable
 -  Auto-scales to number of available CPUs by default
 
-Current Limitations
+Limitations
 ~~~~~~~~~~~~~~~~~~~
 
+-  `MongoDB Replication <https://docs.mongodb.com/manual/replication>`__ is required on all nodes
 -  The host running 'mongodb-consistent-backup' must have enough disk,
    network and cpu resources to backup all shards in parallel
 -  When MongoDB authentication is used, the same user/password/authdb

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Features
 Limitations
 ~~~~~~~~~~~~~~~~~~~
 
--  `MongoDB Replication <https://docs.mongodb.com/manual/replication>`__ is required on all nodes
+-  `MongoDB Replication <https://docs.mongodb.com/manual/replication>`__ is required on all nodes *(sharding config servers included)*
 -  The host running 'mongodb-consistent-backup' must have enough disk,
    network and cpu resources to backup all shards in parallel
 -  When MongoDB authentication is used, the same user/password/authdb
@@ -55,7 +55,7 @@ Limitations
 Requirements:
 ~~~~~~~~~~~~~
 
--  MongoDB / Percona Server for MongoDB 3.2 and above with `Replication <https://docs.mongodb.com/manual/replication>`__ enabled *(sharding config servers included)*
+-  MongoDB / Percona Server for MongoDB 3.2 and above with `Replication <https://docs.mongodb.com/manual/replication>`__ enabled
 -  Backup consistency depends on consistent server time across all
    hosts! Server time **must be synchronized on all nodes** using ntpd
    and a consistent time source or virtualization guest agent that 

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,8 @@ Current Limitations
 Requirements:
 ~~~~~~~~~~~~~
 
--  MongoDB / Percona Server for MongoDB 3.2 and above with `Replication <https://docs.mongodb.com/manual/replication>`__ enabled *(including config servers)*
+-  MongoDB / Percona Server for MongoDB 3.2 and above
+    -  `MongoDB Replication <https://docs.mongodb.com/manual/replication>`__ enabled, including sharding config servers
 -  Backup consistency depends on consistent server time across all
    hosts! Server time **must be synchronized on all nodes** using ntpd
    and a consistent time source or virtualization guest agent that 

--- a/mongodb_consistent_backup/Backup/Mongodump/Mongodump.py
+++ b/mongodb_consistent_backup/Backup/Mongodump/Mongodump.py
@@ -5,7 +5,7 @@ from math import floor
 from subprocess import check_output
 from time import sleep
 
-from mongodb_consistent_backup.Common import MongoUri, config_to_string
+from mongodb_consistent_backup.Common import config_to_string
 from mongodb_consistent_backup.Errors import OperationError
 from mongodb_consistent_backup.Oplog import OplogState
 from mongodb_consistent_backup.Pipeline import Task

--- a/mongodb_consistent_backup/Backup/Mongodump/Mongodump.py
+++ b/mongodb_consistent_backup/Backup/Mongodump/Mongodump.py
@@ -154,30 +154,12 @@ class Mongodump(Task):
         }
         options.update(self.version_extra)
         logging.info(
-            "Starting backups using mongodump %s (options: %s)" % (self.version, config_to_string(options)))
+            "Starting backups using mongodump %s (options: %s)" % (self.version, config_to_string(options)),
+        )
+
         for thread in self.dump_threads:
             thread.start()
         self.wait()
-
-        # backup a single sccc/non-replset config server, if exists:
-        if self.sharding:
-            config_server = self.sharding.get_config_server()
-            if config_server and isinstance(config_server, dict):
-                logging.info("Using non-replset backup method for config server mongodump")
-                mongo_uri = MongoUri(config_server['host'], 27019, 'configsvr')
-                self.states['configsvr'] = OplogState(self.manager, mongo_uri)
-                self.dump_threads = [MongodumpThread(
-                    self.states['configsvr'],
-                    mongo_uri,
-                    self.timer,
-                    self.config,
-                    self.backup_dir,
-                    self.version,
-                    self.threads(),
-                    self.do_gzip()
-                )]
-                self.dump_threads[0].start()
-                self.dump_threads[0].join()
 
         self.completed = True
         self.stopped   = True

--- a/mongodb_consistent_backup/Replication/ReplsetSharded.py
+++ b/mongodb_consistent_backup/Replication/ReplsetSharded.py
@@ -45,7 +45,7 @@ class ReplsetSharded:
                 self.replsets[shard_uri.replset] = Replset(self.config, rs_db)
 
         configsvr = self.sharding.get_config_server()
-        if configsvr and isinstance(configsvr, Replset):
+        if configsvr:
             config_rs_name = configsvr.get_rs_name()
             self.replsets[config_rs_name] = configsvr
 

--- a/mongodb_consistent_backup/Sharding.py
+++ b/mongodb_consistent_backup/Sharding.py
@@ -192,11 +192,9 @@ class Sharding:
                     logging.debug("Re-using seed connection to config server(s)")
                 else:
                     self.config_db = DB(configdb_uri, self.config, True)
-                if self.config_db.is_replset():
-                    self.config_server = Replset(self.config, self.config_db)
-                else:
-                    self.config_server = {'host': configdb_uri.hosts()}
-                    self.config_db.close()
+                if not self.config_db.is_replset():
+                    raise OperationError("configsvrs must have replication enabled")
+                self.config_server = Replset(self.config, self.config_db)
             except Exception, e:
                 logging.fatal("Unable to locate config servers using %s: %s!" % (self.db.uri, e))
                 raise OperationError(e)

--- a/scripts/travis-ci/run-cluster.sh
+++ b/scripts/travis-ci/run-cluster.sh
@@ -7,7 +7,7 @@ function print_usage() {
 	echo "Usage $0: [MONGO_VERSION] [mongodb-consistent-backup EXTRA FLAGS...]"
 }
 
-MONGO_VERSION=$1:-3.4}
+MONGO_VERSION=${1:-3.4}
 MCB_EXTRA="${@:2}"
 
 pushd $(dirname $0)

--- a/scripts/travis-ci/run-cluster.sh
+++ b/scripts/travis-ci/run-cluster.sh
@@ -4,12 +4,11 @@ set -e
 set -x
 
 function print_usage() {
-	echo "Usage $0: [MONGO_VERSION] [CONFIGSVR_TYPE (CSRS or SCCC)] [mongodb-consistent-backup EXTRA FLAGS...]"
+	echo "Usage $0: [MONGO_VERSION] [mongodb-consistent-backup EXTRA FLAGS...]"
 }
 
-MONGO_VERSION=${1:-3.2}
-CONFIGSVR_TYPE=${2:-CSRS}
-MCB_EXTRA="${@:3}"
+MONGO_VERSION=$1:-3.4}
+MCB_EXTRA="${@:2}"
 
 pushd $(dirname $0)
 	source $PWD/func.sh
@@ -19,19 +18,8 @@ pushd $(dirname $0)
 	export MCB_EXTRA=${MCB_EXTRA}
 
 	CONFIGSVR_REPLSET=csReplSet
-	if [ "${CONFIGSVR_TYPE}" == "CSRS" ]; then
-		export CONFIGSVR_FLAGS="--replSet=${CONFIGSVR_REPLSET}"
-		export MONGOS_CONFIGDB="${CONFIGSVR_REPLSET}/mongo-cs-1:27017,mongo-cs-2:27017,mongo-cs-3:27017"
-		echo "# Using CSRS-based config servers: '${MONGOS_CONFIGDB}'"
-	elif [ "${CONFIGSVR_TYPE}" == "SCCC" ]; then
-		export CONFIGSVR_FLAGS=
-		export MONGOS_CONFIGDB="mongo-cs-1:27017,mongo-cs-2:27017"
-		echo "# Using SCCC-based config servers: '${MONGOS_CONFIGDB}'"
-	else
-		echo "Unsupported CONFIGSVR_TYPE field: '${CONFIGSVR_TYPE}'! Supported: CSRS (default) or SCCC"
-		print_usage
-		exit 1
-	fi
+	export CONFIGSVR_FLAGS="--replSet=${CONFIGSVR_REPLSET}"
+	export MONGOS_CONFIGDB="${CONFIGSVR_REPLSET}/mongo-cs-1:27017,mongo-cs-2:27017,mongo-cs-3:27017"
 
 	# start mongo-mongos service (which starts the whole cluster)
 	echo "# Starting instances with docker-compose"
@@ -40,18 +28,16 @@ pushd $(dirname $0)
 	echo "# Waiting 10 seconds"
 	sleep 10
 	
-	if [ "${CONFIGSVR_TYPE}" == "CSRS" ]; then
-		echo "# Initiating csReplSet (config server replica set)"
-		doMongo mongo-mongos mongo-cs-1:27017 'rs.initiate({
-		  _id: "csReplSet",
-		  configsvr: true,
-		  members: [
-		    { _id: 0, host: "mongo-cs-1:27017" },
-		    { _id: 1, host: "mongo-cs-2:27017" },
-		    { _id: 2, host: "mongo-cs-3:27017" }
-		  ]
-		})'
-	fi
+	echo "# Initiating csReplSet (config server replica set)"
+	doMongo mongo-mongos mongo-cs-1:27017 'rs.initiate({
+	  _id: "csReplSet",
+	  configsvr: true,
+	  members: [
+	    { _id: 0, host: "mongo-cs-1:27017" },
+	    { _id: 1, host: "mongo-cs-2:27017" },
+	    { _id: 2, host: "mongo-cs-3:27017" }
+	  ]
+	})'
 	
 	echo "# Initiating rs0"
 	doMongo mongo-mongos mongo-rs0-1:27017 'rs.initiate({


### PR DESCRIPTION
1. Remove support for sharded clusters using the deprecated SCCC-mode config servers. This affects sharded clusters on 3.0 or older and 3.2 in old/SCCC-mode. We cannot guarantee consistency in SCCC-mode, so this is the safest approach. Also versions 3.0 and 3.2 are very old. This resolves #233
1. Throw error for SCCC-mode config servers, if they exist
1. Update travis-ci test scripts to only expect replset-based configsvrs
1. Update version requirements in README
1. Remove 'Roadmap' section of README