### PR TITLE
Fix sanity checking for member score

### DIFF
--- a/mongodb_consistent_backup/Replication/Replset.py
+++ b/mongodb_consistent_backup/Replication/Replset.py
@@ -256,7 +256,7 @@ class Replset:
                 else:
                     log_msg = "Found SECONDARY %s with too high replication lag! Skipping" % member_uri
 
-                if self.secondary['score'] == 0:
+                if self.secondary is not None and self.secondary['score'] == 0:
                     logging.error("Chosen SECONDARY %s has a score of zero/0! This is unexpected, exiting" % member_uri)
                     raise OperationError("Chosen SECONDARY %s has a score of zero/0!" % member_uri)
 


### PR DESCRIPTION
The check was causing exceptions in case there was no secondary
set due to the conditions before:

```
[ERROR] [MainProcess] [Main:exception:208] Failed to start oplog tailing threads! Error: 'NoneType' object has no attribute '__getitem__'
Traceback (most recent call last):
  File ".../mongodb_consistent_backup/Main.py", line 363, in run
    self.oplogtailer.run()
  File ".../mongodb_consistent_backup/Oplog/Tailer/Tailer.py", line 56, in run
    secondary   = self.replsets[shard].find_secondary()
  File ".../mongodb_consistent_backup/Replication/Replset.py", line 259, in find_secondary
    if self.secondary['score'] == 0:
TypeError: 'NoneType' object has no attribute '__getitem__'
```

Added "is not None" to the check condition to ensure the score is only validated
if a secondary is actually set.