### PR TITLE
Add new 'simple' oplog tailer method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ jobs:
       script:
         - docker load -i $TRAVIS_BUILD_DIR/docker/mongodb_consistent_backup.tar
         - $TRAVIS_BUILD_DIR/scripts/travis-ci/run-cluster.sh 3.4
+    - stage: test-cluster-3.4-simple-oplog
+      script:
+        - docker load -i $TRAVIS_BUILD_DIR/docker/mongodb_consistent_backup.tar
+        - $TRAVIS_BUILD_DIR/scripts/travis-ci/run-cluster.sh 3.4 --oplog.tailer.method simple
     - stage: test-replset-3.4
       script:
         - docker load -i $TRAVIS_BUILD_DIR/docker/mongodb_consistent_backup.tar

--- a/conf/mongodb-consistent-backup.example.conf
+++ b/conf/mongodb-consistent-backup.example.conf
@@ -44,6 +44,7 @@ production:
   #  resolver:
   #    threads: [1+]  (default: 2 per CPU)
   #  tailer:
+  #    method: [tailer|simple]  (default: tailer)
   #    enabled: true
   #    status_interval: 30
   archive:

--- a/mongodb_consistent_backup/Oplog/Common/OplogTask.py
+++ b/mongodb_consistent_backup/Oplog/Common/OplogTask.py
@@ -1,0 +1,58 @@
+import logging
+import os
+from time import sleep
+
+from mongodb_consistent_backup.Pipeline import Task
+
+
+class OplogTask(Task):
+    def __init__(self, manager, config, timer, base_dir, backup_dir, replsets, backup_stop):
+        super(OplogTask, self).__init__(self.__class__.__name__, manager, config, timer, base_dir, backup_dir)
+
+        self.backup_name = self.config.name
+        self.user        = self.config.username
+        self.password    = self.config.password
+        self.authdb      = self.config.authdb
+        self.status_secs = self.config.oplog.tailer.status_interval
+        self.replsets    = replsets
+        self.backup_stop = backup_stop
+        self._enabled    = self.config.oplog.tailer.enabled
+
+        self.compression_supported = ['none', 'gzip']
+        self.shards                = {}
+        self._summary              = {}
+
+    def enabled(self):
+        if isinstance(self._enabled, bool):
+            return self._enabled
+        elif isinstance(self._enabled, str) and self._enabled.strip().lower() != 'false':
+            return True
+        return False
+
+    def summary(self):
+        return self._summary
+
+    def get_summaries(self):
+        for shard in self.shards:
+            state = self.shards[shard].get('state')
+            self._summary[shard] = state.get().copy()
+
+    def prepare_oplog_files(self, shard_name):
+        oplog_dir = os.path.join(self.backup_dir, shard_name)
+        if not os.path.isdir(oplog_dir):
+            os.mkdir(oplog_dir)
+        oplog_file = os.path.join(oplog_dir, "oplog-tailed.bson")
+        return oplog_file
+
+    def close(self):
+        if not self.enabled():
+            return
+        for shard in self.shards:
+            try:
+                self.shards[shard]['stop'].set()
+                thread = self.shards[shard]['thread']
+                thread.terminate()
+                while thread.is_alive():
+                    sleep(0.5)
+            except Exception, e:
+                logging.error("Cannot stop oplog task thread: %s" % e)

--- a/mongodb_consistent_backup/Oplog/Common/__init__.py
+++ b/mongodb_consistent_backup/Oplog/Common/__init__.py
@@ -1,0 +1,1 @@
+from OplogTask import OplogTask # NOQA

--- a/mongodb_consistent_backup/Oplog/Resolver/Resolver.py
+++ b/mongodb_consistent_backup/Oplog/Resolver/Resolver.py
@@ -149,9 +149,9 @@ class Resolver(Task):
                 self._pool.join()
             self.completed = True
             logging.info("Oplog resolving completed in %.2f seconds" % self.timer.duration(self.timer_name))
-        # except Exception, e:
-        #     logging.error("Resolver failed for %s: %s" % (uri, e))
-        #     raise e
+        except Exception, e:
+            logging.error("Resolver failed for %s: %s" % (uri, e))
+            raise e
         finally:
             self.timer.stop(self.timer_name)
             self.running = False

--- a/mongodb_consistent_backup/Oplog/Resolver/ResolverThread.py
+++ b/mongodb_consistent_backup/Oplog/Resolver/ResolverThread.py
@@ -26,6 +26,7 @@ class ResolverThread(PoolThread):
         self.flush_secs = self.config['oplog']['flush']['max_secs']
 
         self.oplogs  = {}
+        self.last_ts = None
         self.changes = 0
         self.stopped = False
 

--- a/mongodb_consistent_backup/Oplog/SimpleOplogGetter/SimpleOplogGetter.py
+++ b/mongodb_consistent_backup/Oplog/SimpleOplogGetter/SimpleOplogGetter.py
@@ -1,0 +1,128 @@
+import logging
+
+from multiprocessing import Event
+from time import sleep
+
+from SimpleOplogGetterThread import SimpleOplogGetterThread
+from mongodb_consistent_backup.Errors import OperationError
+from mongodb_consistent_backup.Oplog import OplogState
+from mongodb_consistent_backup.Oplog.Common.OplogTask import OplogTask
+
+
+class SimpleOplogGetter(OplogTask):
+    def __init__(self, manager, config, timer, base_dir, backup_dir, replsets, backup_stop):
+        super(SimpleOplogGetter, self).__init__(manager, config, timer, base_dir, backup_dir, replsets, backup_stop)
+        self.worker_threads        = []
+        self.backup_summary        = {}
+
+    def run(self):
+        if not self.enabled():
+            logging.info("Oplog getter is disabled, skipping")
+            return
+        logging.info("Starting oplog getter for all replica sets (options: compression=%s, status_secs=%i)" % (self.compression(), self.status_secs))
+        self.timer.start(self.timer_name)
+
+        if len(self.backup_summary) == 0:
+            raise OperationError("Oplogs cannot gathered without a successful backup first.")
+
+        # Determine the time when the last shard completed its backup, because we need all changes
+        # across all other shards since whenever they finished until then
+        logging.debug("Finding latest finished backup timestamp")
+        need_changes_until_ts = None
+        for shard in self.replsets:
+            ts = self.backup_summary[shard].get('last_ts')
+            logging.debug("Shard %s's has changes up to %s" % (shard, ts))
+            if need_changes_until_ts is None or ts > need_changes_until_ts:
+                need_changes_until_ts = ts
+
+        logging.info("Getting oplogs for all shards up to %s" % need_changes_until_ts)
+        for shard in self.replsets:
+            getter_stop   = Event()
+            secondary   = self.replsets[shard].find_secondary()
+            mongo_uri   = secondary['uri']
+            shard_name  = mongo_uri.replset
+            need_changes_since_ts = self.backup_summary[shard].get('last_ts')
+            oplog_file  = self.prepare_oplog_files(shard_name)
+            oplog_state = OplogState(self.manager, mongo_uri, oplog_file)
+            thread = SimpleOplogGetterThread(
+                self.backup_stop,
+                getter_stop,
+                mongo_uri,
+                self.config,
+                self.timer,
+                oplog_file,
+                oplog_state,
+                self.do_gzip(),
+                need_changes_since_ts,
+                need_changes_until_ts
+            )
+            self.shards[shard] = {
+                'stop':   getter_stop,
+                'thread': thread,
+                'state':  oplog_state
+            }
+            self.worker_threads.append(thread)
+            logging.debug("Starting thread %s to write %s oplog to %s" % (thread.name, mongo_uri, oplog_file))
+            thread.start()
+        # Wait for all threads to complete
+        self.wait()
+
+        # Wait would have thrown an error is not all of them completed
+        # normally.
+        self.completed = True
+        self.stopped   = True
+        self.get_summaries()
+
+        return self._summary
+
+    def wait(self):
+        completed = 0
+        start_threads = len(self.worker_threads)
+        # wait for all threads to finish
+        logging.debug("Waiting for %d oplog threads to finish" % start_threads)
+        while len(self.worker_threads) > 0:
+            if self.backup_stop and self.backup_stop.is_set():
+                logging.error("Received backup stop event due to error(s), stopping backup!")
+                raise OperationError("Received backup stop event due to error(s)")
+            for thread in self.worker_threads:
+                if not thread.is_alive():
+                    logging.debug("Thread %s exited with code %d" % (thread, thread.exitcode))
+                    if thread.exitcode == 0:
+                        completed += 1
+                    self.worker_threads.remove(thread)
+                else:
+                    logging.debug("Waiting for %s to finish" % thread.name)
+            sleep(1)
+
+        # check if all threads completed
+        if completed == start_threads:
+            logging.info("All oplog threads completed successfully")
+            self.timer.stop(self.timer_name)
+        else:
+            raise OperationError("%d oplog getter threads failed to complete successfully!" % (start_threads - completed))
+
+    def stop(self, kill=False, sleep_secs=3):
+        if not self.enabled():
+            return
+        logging.info("Stopping all oplog tailers")
+        for shard in self.shards:
+            state   = self.shards[shard]['state']
+            thread  = self.shards[shard]['thread']
+
+            # set thread stop event
+            self.shards[shard]['stop'].set()
+            if kill:
+                thread.terminate()
+            sleep(1)
+
+            # wait for thread to stop
+            while thread.is_alive():
+                logging.info('Waiting for %s getter stop' % thread.name)
+                sleep(sleep_secs)
+
+            # gather state info
+            self._summary[shard] = state.get().copy()
+
+        self.timer.stop(self.timer_name)
+        logging.info("Oplog getter completed in %.2f seconds" % self.timer.duration(self.timer_name))
+        return self._summary

--- a/mongodb_consistent_backup/Oplog/SimpleOplogGetter/SimpleOplogGetterThread.py
+++ b/mongodb_consistent_backup/Oplog/SimpleOplogGetter/SimpleOplogGetterThread.py
@@ -1,0 +1,189 @@
+import logging
+import sys
+
+# noinspection PyPackageRequirements
+from multiprocessing import Process
+from pymongo.errors import AutoReconnect, ConnectionFailure, CursorNotFound, ExceededMaxWaiters
+from pymongo.errors import ExecutionTimeout, NetworkTimeout, NotMasterError, ServerSelectionTimeoutError
+from signal import signal, SIGINT, SIGTERM, SIG_IGN
+from time import time
+
+from mongodb_consistent_backup.Common import DB
+from mongodb_consistent_backup.Errors import OperationError
+from mongodb_consistent_backup.Oplog import Oplog
+
+
+class SimpleOplogGetterThread(Process):
+    def __init__(self, backup_stop, tail_stop, uri, config, timer, oplog_file, state, dump_gzip=False, tail_from_ts=None, tail_to_ts=None):
+        Process.__init__(self)
+        self.backup_stop = backup_stop
+        self.tail_stop   = tail_stop
+        self.uri         = uri
+        self.config      = config
+        self.timer       = timer
+        self.oplog_file  = oplog_file
+        self.state       = state
+        self.dump_gzip   = dump_gzip
+        self.flush_docs  = self.config.oplog.flush.max_docs
+        self.flush_secs  = self.config.oplog.flush.max_secs
+        self.status_secs = self.config.oplog.tailer.status_interval
+        self.status_last = time()
+
+        self.cursor_name     = "mongodb_consistent_backup.Oplog.Tailer.TailThread"
+        self.timer_name      = "%s-%s" % (self.__class__.__name__, self.uri.replset)
+        self.db              = None
+        self.conn            = None
+        self.count           = 0
+        self.first_ts        = None
+        self.last_ts         = tail_from_ts
+        self.tail_to_ts      = tail_to_ts
+        self.stopped         = False
+        self._oplog          = None
+        self._cursor         = None
+        self._cursor_addr    = None
+        self.exit_code       = 0
+        self._tail_retry     = 0
+        self._tail_retry_max = 10
+
+        signal(SIGINT, SIG_IGN)
+        signal(SIGTERM, self.close)
+
+    def oplog(self):
+        if not self._oplog:
+            self._oplog = Oplog(
+                self.oplog_file,
+                self.dump_gzip,
+                'w+',
+                self.flush_docs,
+                self.flush_secs
+            )
+        return self._oplog
+
+    def close(self, exit_code=None, frame=None):
+        del exit_code
+        del frame
+        self.tail_stop.set()
+        if self.db:
+            self.db.close()
+        sys.exit(1)
+
+    def check_cursor(self):
+        if self.backup_stop.is_set() or self.tail_stop.is_set():
+            return False
+        elif self._cursor and self._cursor.alive:
+            if self._cursor_addr and self._cursor.address and self._cursor.address != self._cursor_addr:
+                self.backup_stop.set()
+                raise OperationError("Cursor host changed from %s to %s!" % (self._cursor_addr, self._cursor.address))
+            elif not self._cursor_addr:
+                self._cursor_addr = self._cursor.address
+            return True
+        return False
+
+    def status(self):
+        if self.tail_stop.is_set():
+            return
+        now = time()
+        if (now - self.status_last) >= self.status_secs:
+            state = self.state.get()
+            logging.info("Oplog getter %s status: %i oplog changes, ts: %s" % (self.uri, state['count'], state['last_ts']))
+            self.status_last = now
+
+    def connect(self):
+        if not self.db:
+            self.db = DB(self.uri, self.config, True, 'secondary', True)
+        return self.db.connection()
+
+    def run(self):
+        try:
+            logging.info("Getting oplog on %s for changes between %s and %s" % (self.uri, self.last_ts, self.tail_to_ts))
+            self.timer.start(self.timer_name)
+
+            self.state.set('running', True)
+            self.connect()
+            oplog = self.oplog()
+
+            try:
+                # check if the oplog has rolled over by checking against for the earliest timestamp it contains.
+                # This is the same method mongodump does with --oplog
+                if not self.db.is_ts_covered_by_oplog(self.last_ts):
+                    logging.error("Oplog entry for %s has rolled over since %s. Unable to reach a consistent state." % (self.uri, self.last_ts))
+                    raise OperationError("Oplog for %s has rolled over, stopping backup!" % self.uri)
+
+                self._cursor = self.db.get_simple_oplog_cursor_from_to(self.__class__, self.last_ts, self.tail_to_ts)
+                try:
+                    first_iteration_ts = None
+                    for doc in self._cursor:
+                        if first_iteration_ts is None:
+                            # even if we got here, until we actually started reading the cursor, there was still a race between us and
+                            # the oplog being rolled over. So we need to check one last time; again: the same as mongodump --oplog
+                            first_iteration_ts = doc['ts']
+                            if not self.db.is_ts_covered_by_oplog(first_iteration_ts):
+                                logging.error("Oplog entry for %s has rolled over since %s. Unable to reach a consistent state." %
+                                              (self.uri, first_iteration_ts))
+                                raise OperationError("Oplog for %s has rolled over, stopping backup!" % self.uri)
+
+                        if self.last_ts and self.last_ts >= doc['ts']:
+                            continue
+                        oplog.add(doc)
+
+                        # update states
+                        self.count  += 1
+                        self.last_ts = doc['ts']
+                        if self.first_ts is None:
+                            self.first_ts = self.last_ts
+
+                        update = {
+                            'count':    self.count,
+                            'first_ts': self.first_ts,
+                            'last_ts':  self.last_ts
+                        }
+                        self.state.set(None, update, True)
+
+                        # print status report every N seconds
+                        self.status()
+                except NotMasterError:
+                    # pymongo.errors.NotMasterError means a RECOVERING-state when connected to secondary (which should be true)
+                    self.backup_stop.set()
+                    logging.error("Node %s is in RECOVERING state! Stopping oplog getter thread" % self.uri)
+                    raise OperationError("Node %s is in RECOVERING state! Stopping oplog getterthread" % self.uri)
+                except CursorNotFound:
+                    self.backup_stop.set()
+                    logging.error("Cursor disappeared on server %s! Stopping oplog getter thread" % self.uri)
+                    raise OperationError("Cursor disappeared on server %s! Stopping oplog getter thread" % self.uri)
+                except (AutoReconnect, ConnectionFailure, ExceededMaxWaiters, ExecutionTimeout, NetworkTimeout), e:
+                    logging.error("Oplog getter %s received %s exception: %s. Stoppin oplog getter thread." % (self.uri, type(e).__name__, e))
+                    raise OperationError("Oplog getter %s received %s exception: %s. Stoppin oplog getter thread." % (self.uri, type(e).__name__, e))
+            finally:
+                if self._cursor:
+                    logging.debug("Stopping oplog cursor on %s" % self.uri)
+                    self._cursor.close()
+        except OperationError, e:
+            logging.error("Oplog getter %s encountered error: %s" % (self.uri, e))
+            self.exit_code = 1
+            self.backup_stop.set()
+            raise OperationError(e)
+        except ServerSelectionTimeoutError, e:
+            logging.error("Oplog getter %s could not connect: %s" % (self.uri, e))
+            self.exit_code = 1
+            self.backup_stop.set()
+            raise OperationError(e)
+        except Exception, e:
+            logging.error("Oplog getter %s encountered an unexpected error: %s" % (self.uri, e))
+            self.exit_code = 1
+            self.backup_stop.set()
+            raise e
+        finally:
+            oplog.flush()
+            oplog.close()
+            self.stopped = True
+            self.state.set('running', False)
+            self.timer.stop(self.timer_name)
+
+        if self.exit_code == 0:
+            log_msg_extra = "%i oplog changes" % self.count
+            if self.last_ts:
+                log_msg_extra = "%s, end ts: %s" % (log_msg_extra, self.last_ts)
+            logging.info("Done getting oplog on %s, %s" % (self.uri, log_msg_extra))
+            self.state.set('completed', True)
+
+        sys.exit(self.exit_code)

--- a/mongodb_consistent_backup/Oplog/SimpleOplogGetter/__init__.py
+++ b/mongodb_consistent_backup/Oplog/SimpleOplogGetter/__init__.py
@@ -1,0 +1,1 @@
+from SimpleOplogGetter import SimpleOplogGetter # NOQA

--- a/mongodb_consistent_backup/Oplog/__init__.py
+++ b/mongodb_consistent_backup/Oplog/__init__.py
@@ -2,6 +2,7 @@ from Oplog import Oplog  # NOQA
 from OplogState import OplogState  # NOQA
 from Resolver import Resolver  # NOQA
 from Tailer import Tailer  # NOQA
+from SimpleOplogGetter import SimpleOplogGetter # NOQA
 
 
 def config(parser):
@@ -17,4 +18,7 @@ def config(parser):
                         help="Enable/disable capturing of cluster-consistent oplogs, required for cluster-wide PITR (default: true)")
     parser.add_argument("--oplog.tailer.status_interval", dest="oplog.tailer.status_interval", default=30, type=int,
                         help="Number of seconds to wait between reporting oplog tailer status (default: 30)")
+    parser.add_argument("--oplog.tailer.method", dest="oplog.tailer.method", default='tailer', type=str,
+                        help="Method to use for oplog tailing. [tailer|simple] (default: tailer)")
+
     return parser


### PR DESCRIPTION
Adds a new "simple" method for collecting oplogs needed to construct
a consistent backup. It implements an algorithm similar to what mongodump
--oplog already does, albeit for multiple shards.

It does _not_ begin tailing the oplogs for all shards at the beginning
of the backup. Instead, it runs mongodump for all shards and waits until
they have all finished.

Then it collects the delta between when each shard's dump ended and the time
when the last one finished.

The following stages, especially the Resolver, which brings all shard's
oplogs forward to a consistent point in time, are unchanged.

Rationale for this addition:

With the existing "tailer" approach, our backups very often failed with the
error message "Tailer host changed".  This appears to be a common problem
with oplog tailing in general, judging from what you can find on the internet.
It appears that for some reason the oplog tailing cursors get aborted by
mongod with an error stating `"operation exceeded time limit", code: 50`.

With this new simpler oplog fetching method, that apparently does not happen.

The most important difference/drawback compared to the current tailer is that
the simple approach fails if the oplog of one of the shards is so busy that
by the time the deltas are to be collected it has rolled over, so that
operations are no longer available. This, however, will only be the case
on very busy systems where one might argue the oplog size should be increased
anyway.

In general the simple method should be a little less resource intensive, because
there is not additional I/O while mongodumps are runnig.

This change is backwards compatbile for callers. To use the new method, a new
configuration parameter needs to be specified: `--oplog.tailer.method simple`.
The default value for this option is `tailer` which can also be explictly set
to select the classic implementation.

Implementation Notes:
* Common functionality between the original Tailer and the new simple
  implementation was extracted into a new common base class "OplogTask".
* In a few places some variables were extracted or renamed to (hopefully)
  make the code a little more readable, despite the additions.
* In the Resolver class the thread pool's join() method is called to fix
  spurious (harmless) error messages like the following when finishing:

```
Process PoolWorker-8:
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python2.7/multiprocessing/pool.py", line 102, in worker
    task = get()
  File "/usr/lib/python2.7/multiprocessing/queues.py", line 380, in get
    rrelease()
```