### PR TITLE
Add "--backup.mongodump.force_table_scan" option

### DIFF
--- a/mongodb_consistent_backup/Backup/Mongodump/MongodumpThread.py
+++ b/mongodb_consistent_backup/Backup/Mongodump/MongodumpThread.py
@@ -60,6 +60,9 @@ class MongodumpThread(Process):
     def do_ssl(self):
         return parse_config_bool(self.config.ssl.enabled)
 
+    def force_table_scan(self):
+        return parse_config_bool(self.config.backup.mongodump.force_table_scan)
+
     def do_ssl_insecure(self):
         return parse_config_bool(self.config.ssl.insecure)
 
@@ -208,6 +211,10 @@ class MongodumpThread(Process):
             else:
                 logging.fatal("Mongodump must be >= 2.6.0 to enable SSL encryption!")
                 sys.exit(1)
+
+        if self.force_table_scan():
+            logging.info("Enabling mongodump --forceTableScan option")
+            mongodump_flags.append("--forceTableScan")
 
         mongodump_cmd.extend(mongodump_flags)
         return mongodump_cmd

--- a/mongodb_consistent_backup/Backup/Mongodump/__init__.py
+++ b/mongodb_consistent_backup/Backup/Mongodump/__init__.py
@@ -10,4 +10,11 @@ def config(parser):
     parser.add_argument("--backup.mongodump.threads", dest="backup.mongodump.threads",
                         help="Number of threads to use for each mongodump process. There is 1 x mongodump per shard, be careful! (default: shards/CPUs)",
                         default=0, type=int)
+    # for a detailled explanation see
+    # see https://jira.mongodb.org/browse/TOOLS-845?focusedCommentId=988298&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-988298
+    # and https://jira.mongodb.org/browse/TOOLS-845?focusedCommentId=988414&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-988414
+    parser.add_argument("--backup.mongodump.force_table_scan", dest="backup.mongodump.force_table_scan", default=False,
+                        action="store_true", help="Enables mongodump's forceTableScan option. Useful if custom ids are "
+                                                  "used or id values are large. ONLY use with WiredTiger! (default: false)")
+
     return parser


### PR DESCRIPTION
If set, this enables mongodump's `--forceTableScan` option which
can speed up dumps significantly, especially when custom id fields
are used or when the id values are large.

According to the discussion in [TOOLS-845](https://jira.mongodb.org/browse/TOOLS-845)
this is safe to do for WiredTiger.

* https://jira.mongodb.org/browse/TOOLS-845?focusedCommentId=988298&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-988298
* https://jira.mongodb.org/browse/TOOLS-845?focusedCommentId=988414&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-988414

Defaults to false.