### PR TITLE
Fixing potential issues with the rmtree try-catch block

### DIFF
--- a/mongodb_consistent_backup/Rotate.py
+++ b/mongodb_consistent_backup/Rotate.py
@@ -47,7 +47,8 @@ class Rotate(object):
                 logging.debug("Removing backup path: %s" % backup["path"])
                 rmtree(backup["path"])
             except Exception, e:
-                raise OperationError("Unable to remove backup path %s. %s" % (backup["path"], e))
+                logging.error("Unable to remove backup path %s. %s" % (backup["path"], str(e)))
+                raise OperationError(e)
             if self.previous == backup:
                 self.previous = None
             del self.backups[ts]


### PR DESCRIPTION
I've noticed that this except block isn't providing all logging as expected. This commit adds additional error logging.
This commit also moves the exception string to the logging message instead of the error