### PR TITLE
Fix for mongorestore problem

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,7 +155,7 @@ The backups are `mongorestore <https://docs.mongodb.com/manual/reference/program
 
     $ tar xfvz <shardname>.tar.gz
     ...
-    $ mongorestore --host mongod12.example.com --port 27017 -u admin -p 123456 --oplogReplay --dir /var/lib/mongodb-consistent-backup/default/20170424_0000/rs0/dump
+    $ mongorestore --host mongod12.example.com --port 27017 -u admin -p 123456 --oplogReplay --gzip --dir /var/lib/mongodb-consistent-backup/default/20170424_0000/rs0/dump
 
 Run as Docker Container
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
mongorestore doesn't work without `--gzip` option if it was dumped with `--gzip` option. It throws the following error:
`Failed: restore error: error reading oplog bson input: unexpected EOF
`
[Source of solution](https://jira.mongodb.org/browse/TOOLS-1643?focusedCommentId=1556400&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1556400)

The correct mongorestore command should be:
`mongorestore --host mongod12.example.com --port 27017 -u admin -p 123456 --oplogReplay --gzip --dir /var/lib/mongodb-consistent-backup/default/20170424_0000/rs0/dump`
